### PR TITLE
Fix additional security groups / tags

### DIFF
--- a/pkg/cloud/aws/actuators/machine/security_groups.go
+++ b/pkg/cloud/aws/actuators/machine/security_groups.go
@@ -31,7 +31,7 @@ const (
 	// annotation which tracks the SecurityGroups that the machine actuator is
 	// responsible for. These are the SecurityGroups that have been handled by
 	// the AdditionalSecurityGroups in the Machine Provider Config.
-	SecurityGroupsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws/last-applied/security-groups"
+	SecurityGroupsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws-last-applied-security-groups"
 )
 
 // Ensures that the security groups of the machine are correct

--- a/pkg/cloud/aws/actuators/machine/tags.go
+++ b/pkg/cloud/aws/actuators/machine/tags.go
@@ -27,7 +27,7 @@ const (
 	// which tracks the SecurityGroups that the machine actuator is responsible
 	// for. These are the SecurityGroups that have been handled by the
 	// AdditionalTags in the Machine Provider Config.
-	TagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws/last-applied/tags"
+	TagsLastAppliedAnnotation = "sigs.k8s.io/cluster-api-provider-aws-last-applied-tags"
 )
 
 // Ensure that the tags of the machine are correct

--- a/pkg/cloud/aws/converters/instance.go
+++ b/pkg/cloud/aws/converters/instance.go
@@ -17,6 +17,8 @@ limitations under the License.
 package converters
 
 import (
+	"strings"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
@@ -36,13 +38,11 @@ func SDKToInstance(v *ec2.Instance) *v1alpha1.Instance {
 		EBSOptimized: v.EbsOptimized,
 	}
 
+	i.IAMProfile = strings.Split(aws.StringValue(v.IamInstanceProfile.Arn), "instance-profile/")[1]
+
 	for _, sg := range v.SecurityGroups {
 		i.SecurityGroupIDs = append(i.SecurityGroupIDs, *sg.GroupId)
 	}
-
-	// TODO: Handle returned IAM instance profile, since we are currently
-	// using a string representing the name, but the InstanceProfile returned
-	// from the sdk only returns ARN and ID.
 
 	if len(v.Tags) > 0 {
 		i.Tags = TagsToMap(v.Tags)

--- a/pkg/cloud/aws/services/cloudformation/bootstrap.go
+++ b/pkg/cloud/aws/services/cloudformation/bootstrap.go
@@ -176,6 +176,7 @@ func controllersPolicy(accountID string) *iam.PolicyDocument {
 					"ec2:DescribeVpcs",
 					"ec2:DetachInternetGateway",
 					"ec2:DisassociateRouteTable",
+					"ec2:ModifyInstanceAttribute",
 					"ec2:ModifySubnetAttribute",
 					"ec2:ReleaseAddress",
 					"ec2:RevokeSecurityGroupIngress",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:

Currently, the AdditionalSecurityGroups and AdditionalTags fields do not function. This is due to the following:

- `a.isMachineOutdated` always returns true because the Instance struct has no IAMProfile field. This causes the Update function to return, which means `ensureSecurityGroups` and `ensureTags` are never called
- the annotations SecurityGroupsLastAppliedAnnotation and TagsLastAppliedAnnotation don't pass validation, because there are multiple `/`'s
- the bootstrap IAM policy does not have `ec2:ModifyInstanceAttribute`, which is required to add the additional security groups / tags

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes bug where additional security groups and tags are not applied
```