### PR TITLE
Set overrides during a control plane join action

### DIFF
--- a/pkg/cloud/aws/services/kubeadm/aws_defaults.go
+++ b/pkg/cloud/aws/services/kubeadm/aws_defaults.go
@@ -182,4 +182,23 @@ func SetControlPlaneJoinConfigurationOverrides(base *kubeadmv1beta1.JoinConfigur
 	}
 	base.ControlPlane.LocalAPIEndpoint.AdvertiseAddress = localIPV4Lookup
 	base.ControlPlane.LocalAPIEndpoint.BindPort = apiServerBindPort
+
+	if base.NodeRegistration.Name != "" && base.NodeRegistration.Name != hostnameLookup {
+		klog.Infof("Overriding NodeRegistration name from %q to %q. The node registration needs to be dynamically generated in aws.", base.NodeRegistration.Name, hostnameLookup)
+	}
+	base.NodeRegistration.Name = hostnameLookup
+
+	if base.NodeRegistration.CRISocket != "" && base.NodeRegistration.CRISocket != containerdSocket {
+		klog.Infof("Overriding CRISocket from %q to %q. Containerd is only supported container runtime.", base.NodeRegistration.CRISocket, containerdSocket)
+	}
+	base.NodeRegistration.CRISocket = containerdSocket
+
+	if base.NodeRegistration.KubeletExtraArgs == nil {
+		base.NodeRegistration.KubeletExtraArgs = map[string]string{}
+	}
+
+	if cp, ok := base.NodeRegistration.KubeletExtraArgs["cloud-provider"]; ok && cp != cloudProvider {
+		klog.Infof("Overriding node's cloud-provider to the required value of %q.", cloudProvider)
+	}
+	base.NodeRegistration.KubeletExtraArgs["cloud-provider"] = cloudProvider
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
5. If this PR changes image versions, please title this PR "Bump <image name> from x.x.x to y.y.y."
-->

**What this PR does / why we need it**:
Overrides user input for `kubeadm` join configuration during a control plane join action.

```
ubuntu@ip-10-11-10-7:~$ sudo cat /tmp/kubeadm-controlplane-join-config.yaml
apiVersion: kubeadm.k8s.io/v1beta1
caCertPath: ""
controlPlane:
  localAPIEndpoint:
    advertiseAddress: '10.11.10.7'
    bindPort: 6443
discovery:
  bootstrapToken:
    apiServerEndpoint: mv1a-apiserver-1000744507.us-east-1.elb.amazonaws.com:6443
    caCertHashes:
    - sha256:6995ec3f14614f73a25c7c06c5833ecb80ae87f447d8765806c0f0f2bed789cf
    token: otjsql.u74cjrmvusggovcw
    unsafeSkipCAVerification: false
  tlsBootstrapToken: ""
kind: JoinConfiguration
nodeRegistration:
  criSocket: /var/run/containerd/containerd.sock
  kubeletExtraArgs:
    cloud-provider: aws
    cni-bin-dir: /opt/cni/bin
    cni-conf-dir: /etc/cni/net.d
    network-plugin: cni
    node-ip: '10.11.10.7'
  name: 'ip-10-11-10-7.ec2.internal'
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```