### PR TITLE
wip: core sg actuation

### DIFF
--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -371,13 +371,18 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 		return errors.Errorf("found attempt to change immutable state for machine %q: %+q", machine.Name, errs)
 	}
 
+	existingSecurityGroups, err := ec2svc.GetInstanceSecurityGroups(*scope.MachineStatus.InstanceID)
+	if err != nil {
+		return err
+	}
+
 	// Ensure that the security groups are correct.
 	_, err = a.ensureSecurityGroups(
 		ec2svc,
 		scope,
 		*scope.MachineStatus.InstanceID,
 		scope.MachineConfig.AdditionalSecurityGroups,
-		instanceDescription.SecurityGroupIDs,
+		existingSecurityGroups,
 	)
 	if err != nil {
 		return errors.Errorf("failed to apply security groups: %+v", err)

--- a/pkg/cloud/aws/actuators/machine/actuator.go
+++ b/pkg/cloud/aws/actuators/machine/actuator.go
@@ -374,7 +374,7 @@ func (a *Actuator) Update(ctx context.Context, cluster *clusterv1.Cluster, machi
 	// Ensure that the security groups are correct.
 	_, err = a.ensureSecurityGroups(
 		ec2svc,
-		machine,
+		scope,
 		*scope.MachineStatus.InstanceID,
 		scope.MachineConfig.AdditionalSecurityGroups,
 		instanceDescription.SecurityGroupIDs,

--- a/pkg/cloud/aws/actuators/machine/security_groups.go
+++ b/pkg/cloud/aws/actuators/machine/security_groups.go
@@ -21,9 +21,8 @@ import (
 	"sort"
 
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/apis/awsprovider/v1alpha1"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/actuators"
 	service "sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/aws/services"
-
-	clusterv1 "sigs.k8s.io/cluster-api/pkg/apis/cluster/v1alpha1"
 )
 
 const (
@@ -40,13 +39,17 @@ const (
 // Returns bool, error
 // Bool indicates if changes were made or not, allowing the caller to decide
 // if the machine should be updated.
-func (a *Actuator) ensureSecurityGroups(ec2svc service.EC2MachineInterface, machine *clusterv1.Machine, instanceID string, additional []v1alpha1.AWSResourceReference, existing []string) (bool, error) {
-	annotation, err := a.machineAnnotationJSON(machine, SecurityGroupsLastAppliedAnnotation)
+func (a *Actuator) ensureSecurityGroups(ec2svc service.EC2MachineInterface, scope *actuators.MachineScope, instanceID string, additional []v1alpha1.AWSResourceReference, existing []string) (bool, error) {
+	annotation, err := a.machineAnnotationJSON(scope.Machine, SecurityGroupsLastAppliedAnnotation)
 	if err != nil {
 		return false, err
 	}
 
-	changed, ids := a.securityGroupsChanged(annotation, additional, existing)
+	core, err := ec2svc.GetCoreSecurityGroups(scope)
+	if err != nil {
+		return false, err
+	}
+	changed, ids := a.securityGroupsChanged(annotation, core, additional, existing)
 	if !changed {
 		return false, nil
 	}
@@ -61,7 +64,7 @@ func (a *Actuator) ensureSecurityGroups(ec2svc service.EC2MachineInterface, mach
 		newAnnotation[*id.ID] = struct{}{}
 	}
 
-	if err := a.updateMachineAnnotationJSON(machine, SecurityGroupsLastAppliedAnnotation, newAnnotation); err != nil {
+	if err := a.updateMachineAnnotationJSON(scope.Machine, SecurityGroupsLastAppliedAnnotation, newAnnotation); err != nil {
 		return false, err
 	}
 
@@ -69,7 +72,7 @@ func (a *Actuator) ensureSecurityGroups(ec2svc service.EC2MachineInterface, mach
 }
 
 // securityGroupsChanged determines which security groups to delete and which to add.
-func (a *Actuator) securityGroupsChanged(annotation map[string]interface{}, additional []v1alpha1.AWSResourceReference, existing []string) (bool, []string) {
+func (a *Actuator) securityGroupsChanged(annotation map[string]interface{}, core []string, additional []v1alpha1.AWSResourceReference, existing []string) (bool, []string) {
 	state := map[string]bool{}
 	for _, s := range additional {
 		state[*s.ID] = true
@@ -81,6 +84,11 @@ func (a *Actuator) securityGroupsChanged(annotation map[string]interface{}, addi
 		if _, ok := state[groupID]; !ok {
 			state[groupID] = false
 		}
+	}
+
+	// add (or add back) the core security groups
+	for _, s := range core {
+		state[s] = true
 	}
 
 	// Build the security group list.

--- a/pkg/cloud/aws/services/interfaces.go
+++ b/pkg/cloud/aws/services/interfaces.go
@@ -65,6 +65,7 @@ type EC2MachineInterface interface {
 	InstanceIfExists(id *string) (*providerv1.Instance, error)
 	TerminateInstance(id string) error
 	GetCoreSecurityGroups(machine *actuators.MachineScope) ([]string, error)
+	GetInstanceSecurityGroups(id string) (map[string][]string, error)
 	CreateOrGetMachine(machine *actuators.MachineScope, token, kubeConfig string) (*providerv1.Instance, error)
 	UpdateInstanceSecurityGroups(id string, securityGroups []string) error
 	UpdateResourceTags(resourceID *string, create map[string]string, remove map[string]string) error

--- a/pkg/cloud/aws/services/interfaces.go
+++ b/pkg/cloud/aws/services/interfaces.go
@@ -64,6 +64,7 @@ type EC2ClusterInterface interface {
 type EC2MachineInterface interface {
 	InstanceIfExists(id *string) (*providerv1.Instance, error)
 	TerminateInstance(id string) error
+	GetCoreSecurityGroups(machine *actuators.MachineScope) ([]string, error)
 	CreateOrGetMachine(machine *actuators.MachineScope, token, kubeConfig string) (*providerv1.Instance, error)
 	UpdateInstanceSecurityGroups(id string, securityGroups []string) error
 	UpdateResourceTags(resourceID *string, create map[string]string, remove map[string]string) error

--- a/pkg/cloud/aws/services/mocks/services_mock.go
+++ b/pkg/cloud/aws/services/mocks/services_mock.go
@@ -93,6 +93,36 @@ func (mr *MockEC2InterfaceMockRecorder) DeleteNetwork() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetwork", reflect.TypeOf((*MockEC2Interface)(nil).DeleteNetwork))
 }
 
+// GetCoreSecurityGroups mocks base method
+func (m *MockEC2Interface) GetCoreSecurityGroups(arg0 *actuators.MachineScope) ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCoreSecurityGroups", arg0)
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCoreSecurityGroups indicates an expected call of GetCoreSecurityGroups
+func (mr *MockEC2InterfaceMockRecorder) GetCoreSecurityGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCoreSecurityGroups", reflect.TypeOf((*MockEC2Interface)(nil).GetCoreSecurityGroups), arg0)
+}
+
+// GetInstanceSecurityGroups mocks base method
+func (m *MockEC2Interface) GetInstanceSecurityGroups(arg0 string) (map[string][]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstanceSecurityGroups", arg0)
+	ret0, _ := ret[0].(map[string][]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstanceSecurityGroups indicates an expected call of GetInstanceSecurityGroups
+func (mr *MockEC2InterfaceMockRecorder) GetInstanceSecurityGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceSecurityGroups", reflect.TypeOf((*MockEC2Interface)(nil).GetInstanceSecurityGroups), arg0)
+}
+
 // InstanceIfExists mocks base method
 func (m *MockEC2Interface) InstanceIfExists(arg0 *string) (*v1alpha1.Instance, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
I gave this a try on int1a-es's i-00a8355d915b871c1 instance (sorry-not-sorry) via image `gcr.io/cluster-provider-aws-seth-test/cluster-api-aws-controller:actuate-sgs-test`. 

It partially works. But also there's a whole bunch of additional chatter in the manager logs, so I think something's getting caught in an update loop. It's also not actuating against the 2nd ENI on these machines (or so it seems).