### PR TITLE
chore: pass kubelet args through to eksconfig generated userdata

### DIFF
--- a/bootstrap/eks/api/v1alpha3/eksconfig_types.go
+++ b/bootstrap/eks/api/v1alpha3/eksconfig_types.go
@@ -91,11 +91,3 @@ type EKSConfigList struct {
 func init() {
 	SchemeBuilder.Register(&EKSConfig{}, &EKSConfigList{})
 }
-
-func (c *EKSConfig) GetConditions() clusterv1.Conditions {
-	return c.Status.Conditions
-}
-
-func (c *EKSConfig) SetConditions(conditions clusterv1.Conditions) {
-	c.Status.Conditions = conditions
-}

--- a/bootstrap/eks/config/rbac/role.yaml
+++ b/bootstrap/eks/config/rbac/role.yaml
@@ -7,6 +7,17 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
   - bootstrap.cluster.x-k8s.io
   resources:
   - eksconfigs
@@ -26,3 +37,22 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - cluster.x-k8s.io
+  resources:
+  - clusters
+  - machinepools
+  - machines
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - infrastructure.cluster.x-k8s.io
+  resources:
+  - awsclusters
+  - awsmanagedclusters
+  verbs:
+  - get
+  - list
+  - watch

--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -165,7 +165,8 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, scope *EKSConfigSc
 	}
 
 	userDataScript, err := userdata.NewNode(&userdata.NodeInput{
-		ClusterName: scope.Cluster.ClusterName,
+		ClusterName:      scope.Cluster.ClusterName,
+		KubeletExtraArgs: scope.Config.Spec.KubeletExtraArgs,
 	})
 	if err != nil {
 		scope.Error(err, "Failed to create a worker join configuration")

--- a/bootstrap/eks/controllers/eksconfig_controller.go
+++ b/bootstrap/eks/controllers/eksconfig_controller.go
@@ -37,8 +37,6 @@ import (
 	bsutil "sigs.k8s.io/cluster-api/bootstrap/util"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/annotations"
-	"sigs.k8s.io/cluster-api/util/conditions"
-	"sigs.k8s.io/cluster-api/util/patch"
 
 	bootstrapv1 "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/api/v1alpha3"
 	"sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/internal/userdata"
@@ -60,6 +58,9 @@ type EKSConfigScope struct {
 
 // +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=eksconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=bootstrap.cluster.x-k8s.io,resources=eksconfigs/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsclusters;awsmanagedclusters,verbs=get;list;watch;
+// +kubebuilder:rbac:groups=cluster.x-k8s.io,resources=machines;machinepools;clusters,verbs=get;list;watch;
+// +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;delete;
 
 func (r *EKSConfigReconciler) Reconcile(req ctrl.Request) (_ ctrl.Result, rerr error) {
 	ctx := context.Background()
@@ -151,7 +152,7 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, scope *EKSConfigSc
 
 	if !scope.Cluster.Status.InfrastructureReady {
 		scope.Logger.Info("Cluster infrastructure is not ready, requeueing")
-		conditions.MarkFalse(config,
+		conditions.MarkFalse(scope.Config,
 			bootstrapv1.DataSecretAvailableCondition,
 			bootstrapv1.WaitingForClusterInfrastructureReason,
 			clusterv1.ConditionSeverityInfo, "")
@@ -160,12 +161,15 @@ func (r *EKSConfigReconciler) joinWorker(ctx context.Context, scope *EKSConfigSc
 
 	if !scope.Cluster.Status.ControlPlaneInitialized {
 		scope.Logger.Info("Cluster has not yet been initialized, requeueing")
-		conditions.MarkFalse(scope.Config, bootstrapv1.DataSecretAvailableCondition, bootstrapv1.DataSecretGenerationFailedReason, clusterv1.ConditionSeverityWarning, err.Error())
+		conditions.MarkFalse(scope.Config, bootstrapv1.DataSecretAvailableCondition, bootstrapv1.DataSecretGenerationFailedReason, clusterv1.ConditionSeverityWarning, "")
 		return ctrl.Result{}, nil
 	}
 
+	scope.Logger.Info("generating userdata", "cluster", scope.Cluster.GetName())
+
+	// generate userdata
 	userDataScript, err := userdata.NewNode(&userdata.NodeInput{
-		ClusterName:      scope.Cluster.ClusterName,
+		ClusterName:      scope.Cluster.GetName(),
 		KubeletExtraArgs: scope.Config.Spec.KubeletExtraArgs,
 	})
 	if err != nil {

--- a/bootstrap/eks/internal/userdata/kubelet_args.go
+++ b/bootstrap/eks/internal/userdata/kubelet_args.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userdata
+
+const argsTemplate = `{{- define "args" -}}
+{{- if . }} --kubelet-extra-args="{{ template "kubeletArgsTemplate" . }}"
+{{- end -}}
+{{- end -}}`
+
+const kubeletArgsTemplate = `{{- define "kubeletArgsTemplate" -}}
+{{- $first := true -}}
+{{- range $k, $v := . -}}
+{{- if $first -}}{{ $first = false -}}{{- else }} {{ end -}}
+--{{$k}}={{$v}}
+{{- end -}}
+{{- end -}}
+`

--- a/bootstrap/eks/internal/userdata/kubelet_args.go
+++ b/bootstrap/eks/internal/userdata/kubelet_args.go
@@ -17,7 +17,7 @@ limitations under the License.
 package userdata
 
 const argsTemplate = `{{- define "args" -}}
-{{- if . }} --kubelet-extra-args="{{ template "kubeletArgsTemplate" . }}"
+{{- if . }} --kubelet-extra-args '{{ template "kubeletArgsTemplate" . }}'
 {{- end -}}
 {{- end -}}`
 

--- a/bootstrap/eks/internal/userdata/node_test.go
+++ b/bootstrap/eks/internal/userdata/node_test.go
@@ -60,7 +60,7 @@ func TestNewNode(t *testing.T) {
 				},
 			},
 			expectedBytes: []byte(`#!/bin/bash
-/etc/eks/bootstrap.sh test-cluster --kubelet-extra-args="--foo=bar --pizza-topping=pepperoni"
+/etc/eks/bootstrap.sh test-cluster --kubelet-extra-args '--foo=bar --pizza-topping=pepperoni'
 `),
 			expectErr: false,
 		},

--- a/bootstrap/eks/internal/userdata/node_test.go
+++ b/bootstrap/eks/internal/userdata/node_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package userdata
+
+import (
+	"testing"
+
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
+)
+
+func TestNewNode(t *testing.T) {
+	format.TruncatedDiff = false
+	g := NewWithT(t)
+
+	type args struct {
+		input *NodeInput
+	}
+	tests := []struct {
+		name          string
+		args          args
+		expectedBytes []byte
+		expectErr     bool
+	}{
+		{
+			name: "success case",
+			args: args{
+				input: &NodeInput{
+					ClusterName: "test-cluster",
+				},
+			},
+			expectedBytes: []byte(`#!/bin/bash
+/etc/eks/bootstrap.sh test-cluster
+`),
+			expectErr: false,
+		},
+		{
+			name: "with extra args",
+			args: args{
+				input: &NodeInput{
+					ClusterName: "test-cluster",
+					KubeletExtraArgs: map[string]string{
+						"foo":           "bar",
+						"pizza-topping": "pepperoni",
+					},
+				},
+			},
+			expectedBytes: []byte(`#!/bin/bash
+/etc/eks/bootstrap.sh test-cluster --kubelet-extra-args="--foo=bar --pizza-topping=pepperoni"
+`),
+			expectErr: false,
+		},
+	}
+	for _, testcase := range tests {
+		t.Run(testcase.name, func(t *testing.T) {
+			bytes, err := NewNode(testcase.args.input)
+			if testcase.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(string(bytes)).To(Equal(string(testcase.expectedBytes)))
+		})
+	}
+}

--- a/bootstrap/eks/main.go
+++ b/bootstrap/eks/main.go
@@ -39,6 +39,7 @@ import (
 	eksbootstrapv1alpha3 "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/api/v1alpha3"
 	eksbootstrapcontrollers "sigs.k8s.io/cluster-api-provider-aws/bootstrap/eks/controllers"
 	"sigs.k8s.io/cluster-api-provider-aws/version"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -51,6 +52,7 @@ func init() {
 	klog.InitFlags(nil)
 
 	_ = clientgoscheme.AddToScheme(scheme)
+	_ = clusterv1.AddToScheme(scheme)
 	_ = eksbootstrapv1alpha3.AddToScheme(scheme)
 	// +kubebuilder:scaffold:scheme
 }


### PR DESCRIPTION
I strongly dislike templating things in this way but I can't think of a reasonable alternative.

We could switch from bash to using cloud-init once again but there'd still be the annoying bit of templating the kubeletExtraArgs as a single flag.

