### PR TITLE
lookup ami in machinepool when none is specified

### DIFF
--- a/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/exp.infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -112,6 +112,15 @@ spec:
                   id:
                     description: all the things needed for a launch template
                     type: string
+                  imageLookupBaseOS:
+                    description: ImageLookupBaseOS is the name of the base operating system to use for image lookup the AMI is not set.
+                    type: string
+                  imageLookupFormat:
+                    description: 'ImageLookupFormat is the AMI naming format to look up the image for this machine It will be ignored if an explicit AMI is set. Supports substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and kubernetes version, respectively. The BaseOS will be the value in ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as defined by the packages produced by kubernetes/release without v as a prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See also: https://golang.org/pkg/text/template/'
+                    type: string
+                  imageLookupOrg:
+                    description: ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.
+                    type: string
                   instanceType:
                     description: 'InstanceType is the type of instance to create. Example: m4.xlarge'
                     type: string

--- a/exp/api/v1alpha3/types.go
+++ b/exp/api/v1alpha3/types.go
@@ -51,6 +51,27 @@ type AWSLaunchTemplate struct {
 	// todo: use a helper
 	AMI infrav1.AWSResourceReference `json:"ami,omitempty"`
 
+	// ImageLookupFormat is the AMI naming format to look up the image for this
+	// machine It will be ignored if an explicit AMI is set. Supports
+	// substitutions for {{.BaseOS}} and {{.K8sVersion}} with the base OS and
+	// kubernetes version, respectively. The BaseOS will be the value in
+	// ImageLookupBaseOS or ubuntu (the default), and the kubernetes version as
+	// defined by the packages produced by kubernetes/release without v as a
+	// prefix: 1.13.0, 1.12.5-mybuild.1, or 1.17.3. For example, the default
+	// image format of capa-ami-{{.BaseOS}}-?{{.K8sVersion}}-* will end up
+	// searching for AMIs that match the pattern capa-ami-ubuntu-?1.18.0-* for a
+	// Machine that is targeting kubernetes v1.18.0 and the ubuntu base OS. See
+	// also: https://golang.org/pkg/text/template/
+	// +optional
+	ImageLookupFormat string `json:"imageLookupFormat,omitempty"`
+
+	// ImageLookupOrg is the AWS Organization ID to use for image lookup if AMI is not set.
+	ImageLookupOrg string `json:"imageLookupOrg,omitempty"`
+
+	// ImageLookupBaseOS is the name of the base operating system to use for
+	// image lookup the AMI is not set.
+	ImageLookupBaseOS string `json:"imageLookupBaseOS,omitempty"`
+
 	// InstanceType is the type of instance to create. Example: m4.xlarge
 	InstanceType string `json:"instanceType,omitempty"`
 

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -58,8 +58,6 @@ func (s *Service) GetLaunchTemplate(name string) (*expinfrav1.AWSLaunchTemplate,
 // CreateLaunchTemplate generates a launch template to be used with the autoscaling group
 func (s *Service) CreateLaunchTemplate(scope *scope.MachinePoolScope, userData []byte) (*expinfrav1.AWSLaunchTemplate, error) {
 	s.scope.Info("Create a new launch template")
-	s.scope.Info("UserData", "UserData", string(userData))
-	s.scope.Info(scope.Name())
 
 	launchTemplateData, err := s.createLaunchTemplateData(scope, userData)
 	if err != nil {
@@ -120,7 +118,6 @@ func (s *Service) createLaunchTemplateData(scope *scope.MachinePoolScope, userDa
 	lt := scope.AWSMachinePool.Spec.AWSLaunchTemplate
 
 	data := &ec2.RequestLaunchTemplateData{
-		ImageId:      lt.AMI.ID,
 		InstanceType: aws.String(lt.InstanceType),
 		IamInstanceProfile: &ec2.LaunchTemplateIamInstanceProfileSpecificationRequest{
 			Name: aws.String(lt.IamInstanceProfile),
@@ -201,6 +198,39 @@ func (s *Service) createLaunchTemplateData(scope *scope.MachinePoolScope, userDa
 		data.SecurityGroupIds = append(data.SecurityGroupIds, additionalGroup.ID)
 	}
 	s.scope.Info("Security Groups", "security groups", data.SecurityGroupIds)
+
+	// Pick image from the machinepool configuration, or use a default one.
+	if scope.AWSMachinePool.Spec.AWSLaunchTemplate.AMI.ID != nil { // nolint:nestif
+		data.ImageId = scope.AWSMachinePool.Spec.AWSLaunchTemplate.AMI.ID
+	} else {
+		if scope.MachinePool.Spec.Template.Spec.Version == nil {
+			err := errors.New("Either AWSMachinePool's spec.awslaunchtemplate.ami.id or MachinePool's spec.template.spec.version must be defined")
+			s.scope.Error(err, "")
+			return nil, err
+		}
+
+		imageLookupFormat := scope.AWSMachinePool.Spec.AWSLaunchTemplate.ImageLookupFormat
+		if imageLookupFormat == "" {
+			imageLookupFormat = scope.AWSCluster.Spec.ImageLookupFormat
+		}
+
+		imageLookupOrg := scope.AWSMachinePool.Spec.AWSLaunchTemplate.ImageLookupOrg
+		if imageLookupOrg == "" {
+			imageLookupOrg = scope.AWSCluster.Spec.ImageLookupOrg
+		}
+
+		imageLookupBaseOS := scope.AWSMachinePool.Spec.AWSLaunchTemplate.ImageLookupBaseOS
+		if imageLookupBaseOS == "" {
+			imageLookupBaseOS = scope.AWSCluster.Spec.ImageLookupBaseOS
+		}
+
+		lookupAMI, err := s.defaultAMILookup(imageLookupFormat, imageLookupOrg, imageLookupBaseOS, *scope.MachinePool.Spec.Template.Spec.Version)
+
+		if err != nil {
+			return nil, err
+		}
+		data.ImageId = aws.String(lookupAMI)
+	}
 
 	return data, nil
 }

--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -200,8 +200,8 @@ func (s *Service) createLaunchTemplateData(scope *scope.MachinePoolScope, userDa
 	s.scope.Info("Security Groups", "security groups", data.SecurityGroupIds)
 
 	// Pick image from the machinepool configuration, or use a default one.
-	if scope.AWSMachinePool.Spec.AWSLaunchTemplate.AMI.ID != nil { // nolint:nestif
-		data.ImageId = scope.AWSMachinePool.Spec.AWSLaunchTemplate.AMI.ID
+	if lt.AMI.ID != nil { // nolint:nestif
+		data.ImageId = lt.AMI.ID
 	} else {
 		if scope.MachinePool.Spec.Template.Spec.Version == nil {
 			err := errors.New("Either AWSMachinePool's spec.awslaunchtemplate.ami.id or MachinePool's spec.template.spec.version must be defined")
@@ -209,17 +209,17 @@ func (s *Service) createLaunchTemplateData(scope *scope.MachinePoolScope, userDa
 			return nil, err
 		}
 
-		imageLookupFormat := scope.AWSMachinePool.Spec.AWSLaunchTemplate.ImageLookupFormat
+		imageLookupFormat := lt.ImageLookupFormat
 		if imageLookupFormat == "" {
 			imageLookupFormat = scope.AWSCluster.Spec.ImageLookupFormat
 		}
 
-		imageLookupOrg := scope.AWSMachinePool.Spec.AWSLaunchTemplate.ImageLookupOrg
+		imageLookupOrg := lt.ImageLookupOrg
 		if imageLookupOrg == "" {
 			imageLookupOrg = scope.AWSCluster.Spec.ImageLookupOrg
 		}
 
-		imageLookupBaseOS := scope.AWSMachinePool.Spec.AWSLaunchTemplate.ImageLookupBaseOS
+		imageLookupBaseOS := lt.ImageLookupBaseOS
 		if imageLookupBaseOS == "" {
 			imageLookupBaseOS = scope.AWSCluster.Spec.ImageLookupBaseOS
 		}


### PR DESCRIPTION
You can try it out too! Remove `spec.awsLaunchTemplate.ami.id` from your awsmachinepool, and ensure your machinepool has a `spec.template.spec.version`