### PR TITLE
Adds Integration Test for AWSMachinePool Controller 

### DIFF
--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -18,8 +18,10 @@ package v1alpha3
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/errors"
 )
 
 const (
@@ -66,6 +68,44 @@ type AWSMachinePoolStatus struct {
 	AutoScalingGroupARN string               `json:"autoScalingGroupARN,omitempty"`
 	Conditions          clusterv1.Conditions `json:"conditions,omitempty"`
 	LaunchTemplateID    string               `json:"launchTemplateID,omitempty"`
+
+	// FailureReason will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a succinct value suitable
+	// for machine interpretation.
+	//
+	// This field should not be set for transitive errors that a controller
+	// faces that are expected to be fixed automatically over
+	// time (like service outages), but instead indicate that something is
+	// fundamentally wrong with the Machine's spec or the configuration of
+	// the controller, and that manual intervention is required. Examples
+	// of terminal errors would be invalid combinations of settings in the
+	// spec, values that are unsupported by the controller, or the
+	// responsible controller itself being critically misconfigured.
+	//
+	// Any transient errors that occur during the reconciliation of Machines
+	// can be added as events to the Machine object and/or logged in the
+	// controller's output.
+	// +optional
+	FailureReason *errors.MachineStatusError `json:"failureReason,omitempty"`
+
+	// FailureMessage will be set in the event that there is a terminal problem
+	// reconciling the Machine and will contain a more verbose string suitable
+	// for logging and human consumption.
+	//
+	// This field should not be set for transitive errors that a controller
+	// faces that are expected to be fixed automatically over
+	// time (like service outages), but instead indicate that something is
+	// fundamentally wrong with the Machine's spec or the configuration of
+	// the controller, and that manual intervention is required. Examples
+	// of terminal errors would be invalid combinations of settings in the
+	// spec, values that are unsupported by the controller, or the
+	// responsible controller itself being critically misconfigured.
+	//
+	// Any transient errors that occur during the reconciliation of Machines
+	// can be added as events to the Machine object and/or logged in the
+	// controller's output.
+	// +optional
+	FailureMessage *string `json:"failureMessage,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -100,4 +140,12 @@ func (r *AWSMachinePool) GetConditions() clusterv1.Conditions {
 
 func (r *AWSMachinePool) SetConditions(conditions clusterv1.Conditions) {
 	r.Status.Conditions = conditions
+}
+
+func (obj *AWSMachinePool) GetObjectKind() schema.ObjectKind {
+	return &obj.TypeMeta
+}
+
+func (obj *AWSMachinePoolList) GetObjectKind() schema.ObjectKind {
+	return &obj.TypeMeta
 }

--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -105,8 +105,7 @@ type AWSMachinePoolStatus struct {
 	// can be added as events to the Machine object and/or logged in the
 	// controller's output.
 	// +optional
-	FailureMessage *string   `json:"failureMessage,omitempty"`
-	ASGState       *ASGState `json:"asgState,omitempty"`
+	FailureMessage *string `json:"failureMessage,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -105,7 +105,8 @@ type AWSMachinePoolStatus struct {
 	// can be added as events to the Machine object and/or logged in the
 	// controller's output.
 	// +optional
-	FailureMessage *string `json:"failureMessage,omitempty"`
+	FailureMessage *string   `json:"failureMessage,omitempty"`
+	ASGState       *ASGState `json:"asgState,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/exp/api/v1alpha3/types.go
+++ b/exp/api/v1alpha3/types.go
@@ -17,7 +17,6 @@ limitations under the License.
 package v1alpha3
 
 import (
-	"k8s.io/apimachinery/pkg/util/sets"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 )
 
@@ -126,7 +125,6 @@ type AutoScalingGroup struct {
 	Subnets         []string          `json:"subnets,omitempty"`
 
 	MixedInstancesPolicy *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
-	State                ASGState              `json:"asgState,omitempty"` //TODO: Is this the same as status?
 	Status               ASGStatus
 	Instances            []infrav1.Instance `json:"instances,omitempty"`
 }
@@ -155,53 +153,3 @@ func LaunchTemplateNeedsUpdate(incoming *AWSLaunchTemplate, existing *AWSLaunchT
 
 	return false
 }
-
-// ASGState contains the state of the ASG. e.g. pending, running, etc
-type ASGState string
-
-//TODO: maybe make it match this more? https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroupLifecycle.html
-var (
-	// ASGStatePending is the string representing an ASG in a pending state
-	ASGStatePending = ASGState("pending")
-
-	// ASGStateRunning is the string representing an ASG in a pending state
-	ASGStateRunning = ASGState("running")
-
-	// ASGStateShuttingDown is the string representing an ASG shutting down
-	ASGStateShuttingDown = ASGState("shutting-down")
-
-	// ASGStateTerminated is the string representing an ASG that has been terminated
-	ASGStateTerminated = ASGState("terminated")
-
-	// ASGStateStopping is the string representing an ASG
-	// that is in the process of being stopped and can be restarted
-	ASGStateStopping = ASGState("stopping")
-
-	// ASGStateStopped is the string representing an ASG
-	// that has been stopped and can be restarted
-	ASGStateStopped = ASGState("stopped")
-
-	// ASGRunningStates defines the set of states in which an EC2 ASG is
-	// running or going to be running soon
-	ASGRunningStates = sets.NewString(
-		string(ASGStatePending),
-		string(ASGStateRunning),
-	)
-
-	// ASGOperationalStates defines the set of states in which an EC2 ASG is
-	// or can return to running, and supports all EC2 operations
-	ASGOperationalStates = ASGRunningStates.Union(
-		sets.NewString(
-			string(ASGStateStopping),
-			string(ASGStateStopped),
-		),
-	)
-
-	// ASGKnownStates represents all known ASG states
-	ASGKnownStates = ASGOperationalStates.Union(
-		sets.NewString(
-			string(ASGStateShuttingDown),
-			string(ASGStateTerminated),
-		),
-	)
-)

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -370,7 +370,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 	machinePoolScope.Info("checking for existing launch template")
 
 	ec2svc := r.getEC2Service(clusterScope)
-	launchTemplate, err := ec2svc.GetLaunchTemplate(machinePoolScope.Name())
+	launchTemplate, err := ec2svc.GetLaunchTemplate(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID)
 	if err != nil {
 		return err
 	}

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -191,7 +191,14 @@ func (r *AWSMachinePoolReconciler) SetupWithManager(mgr ctrl.Manager) error {
 func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoolScope *scope.MachinePoolScope, clusterScope *scope.ClusterScope) (ctrl.Result, error) {
 	clusterScope.Info("Reconciling AWSMachine")
 
-	// todo: check for failure state, return early
+	// If the AWSMachine is in an error state, return early.
+	if machinePoolScope.HasFailed() {
+		machinePoolScope.Info("Error state detected, skipping reconciliation")
+
+		// TODO: If we are in a failed state, delete the secret regardless of instance state
+
+		return ctrl.Result{}, nil
+	}
 
 	// If the AWSMachinepool doesn't have our finalizer, add it
 	controllerutil.AddFinalizer(machinePoolScope.AWSMachinePool, expinfrav1.MachinePoolFinalizer)

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -370,7 +370,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 	machinePoolScope.Info("checking for existing launch template")
 
 	ec2svc := r.getEC2Service(clusterScope)
-	launchTemplate, err := ec2svc.GetLaunchTemplate(machinePoolScope.AWSMachinePool.Status.LaunchTemplateID)
+	launchTemplate, err := ec2svc.GetLaunchTemplate(machinePoolScope.Name())
 	if err != nil {
 		return err
 	}

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -58,7 +58,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 	)
 
 	BeforeEach(func() {
-		var err error //TODO: check out LogToOutput
+		var err error
 
 		if err := flag.Set("logtostderr", "false"); err != nil {
 			_ = fmt.Errorf("Error setting logtostderr flag")

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/golang/mock/gomock"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega/gstruct"
 
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
@@ -230,447 +231,448 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 		// is in progress. in type Group struct {}
 		//  Status *string `min:"1" type:"string"`
 
-		// 	When("ASG creation succeeds", func() {
-		// 		var instance *infrav1.Instance
-		// 		BeforeEach(func() {
-		// 			instance = &infrav1.Instance{
-		// 				ID: "myMachine",
-		// 			}
-		// 			instance.State = infrav1.InstanceStatePending
-
-		// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil)
-		// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil)
-		// 		})
-
-		// 		Context("instance security group errors", func() {
-		// 			BeforeEach(func() {
-		// 				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(nil, errors.New("stop here"))
-		// 			})
-
-		// 			It("should set attributes after creating an instance", func() {
-		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				Expect(ms.AWSMachinePool.Spec.ProviderID).To(PointsTo(Equal("aws:////myMachine")))
-		// 				Expect(ms.AWSMachinePool.Annotations).To(Equal(map[string]string{"cluster-api-provider-aws": "true"}))
-		// 			})
-
-		// 			Context("with captured logging", func() {
-		// 				var buf *bytes.Buffer
-
-		// 				BeforeEach(func() {
-		// 					buf = new(bytes.Buffer)
-		// 					klog.SetOutput(buf)
-		// 				})
-
-		// 				It("should set instance to pending", func() {
-		// 					instance.State = infrav1.InstanceStatePending
-		// 					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 					Expect(ms.AWSMachinePool.Status.InstanceState).To(PointsTo(Equal(infrav1.InstanceStatePending)))
-		// 					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-		// 					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-		// 					expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.InstanceNotReadyReason}})
-		// 				})
-
-		// 				It("should set instance to running", func() {
-		// 					instance.State = infrav1.InstanceStateRunning
-		// 					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 					Expect(ms.AWSMachinePool.Status.InstanceState).To(PointsTo(Equal(infrav1.InstanceStateRunning)))
-		// 					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(true))
-		// 					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-		// 					expectConditions(ms.AWSMachinePool, []conditionAssertion{
-		// 						{conditionType: infrav1.InstanceReadyCondition, status: corev1.ConditionTrue},
-		// 					})
-		// 				})
-		// 			})
-		// 		})
-
-		// 		Context("New EC2 instance state", func() {
-		// 			It("should error when the instance state is a new unseen one", func() {
-		// 				buf := new(bytes.Buffer)
-		// 				klog.SetOutput(buf)
-		// 				instance.State = "NewAWSMachineState"
-		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-		// 				Expect(buf.String()).To(ContainSubstring(("EC2 instance state is undefined")))
-		// 				Eventually(recorder.Events).Should(Receive(ContainSubstring("InstanceUnhandledState")))
-		// 				Expect(ms.AWSMachinePool.Status.FailureMessage).To(PointsTo(Equal("EC2 instance state \"NewAWSMachineState\" is undefined")))
-		// 				expectConditions(ms.AWSMachinePool, []conditionAssertion{{conditionType: infrav1.InstanceReadyCondition, status: corev1.ConditionUnknown}})
-		// 			})
-		// 		})
-
-		// 		Context("Security Groups succeed", func() {
-		// 			BeforeEach(func() {
-		// 				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
-		// 					Return(map[string][]string{"eid": {}}, nil)
-		// 				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil)
-		// 			})
-
-		// 			It("should reconcile security groups", func() {
-		// 				ms.AWSMachinePool.Spec.AdditionalSecurityGroups = []infrav1.AWSResourceReference{
-		// 					{
-		// 						ID: pointer.StringPtr("sg-2345"),
-		// 					},
-		// 				}
-		// 				// ms.AWSMachine.Spec.AdditionalSecurityGroups = []infrav1
-		// 				ec2Svc.EXPECT().UpdateInstanceSecurityGroups(instance.ID, []string{"sg-2345"})
-
-		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				expectConditions(ms.AWSMachinePool, []conditionAssertion{{conditionType: infrav1.SecurityGroupsReadyCondition, status: corev1.ConditionTrue}})
-		// 			})
-
-		// 			It("should not tag anything if there's not tags", func() {
-		// 				ec2Svc.EXPECT().UpdateInstanceSecurityGroups(gomock.Any(), gomock.Any()).Times(0)
-		// 				if _, err := reconciler.reconcileNormal(context.Background(), ms, cs); err != nil {
-		// 					_ = fmt.Errorf("reconcileNormal reutrned an error during test")
-		// 				}
-		// 			})
-
-		// 			It("should tag instances from machine and cluster tags", func() {
-		// 				ms.AWSMachinePool.Spec.AdditionalTags = infrav1.Tags{"kind": "alicorn"}
-		// 				ms.AWSCluster.Spec.AdditionalTags = infrav1.Tags{"colour": "lavender"}
-
-		// 				ec2Svc.EXPECT().UpdateResourceTags(
-		// 					PointsTo("myMachine"),
-		// 					map[string]string{
-		// 						"kind":   "alicorn",
-		// 						"colour": "lavender",
-		// 					},
-		// 					map[string]string{},
-		// 				).Return(nil)
-
-		// 				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				Expect(err).To(BeNil())
-		// 			})
-		// 		})
-
-		// 		When("temporarily stopping then starting the AWSMachine", func() {
-		// 			var buf *bytes.Buffer
-		// 			BeforeEach(func() {
-		// 				buf = new(bytes.Buffer)
-		// 				klog.SetOutput(buf)
-		// 				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
-		// 					Return(map[string][]string{"eid": {}}, nil).Times(1)
-		// 				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-		// 			})
-
-		// 			It("should set instance to stopping and unready", func() {
-		// 				instance.State = infrav1.InstanceStateStopping
-		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				Expect(ms.AWSMachinePool.Status.InstanceState).To(PointsTo(Equal(infrav1.InstanceStateStopping)))
-		// 				Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-		// 				Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-		// 				expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceStoppedReason}})
-		// 			})
-
-		// 			It("should then set instance to stopped and unready", func() {
-		// 				instance.State = infrav1.InstanceStateStopped
-		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				Expect(ms.AWSMachinePool.Status.InstanceState).To(PointsTo(Equal(infrav1.InstanceStateStopped)))
-		// 				Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-		// 				Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-		// 				expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceStoppedReason}})
-		// 			})
-
-		// 			It("should then set instance to running and ready once it is restarted", func() {
-		// 				instance.State = infrav1.InstanceStateRunning
-		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				Expect(ms.AWSMachinePool.Status.InstanceState).To(PointsTo(Equal(infrav1.InstanceStateRunning)))
-		// 				Expect(ms.AWSMachinePool.Status.Ready).To(Equal(true))
-		// 				Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-		// 			})
-		// 		})
-
-		// 		When("deleting the AWSMachine outside of Kubernetes", func() {
-		// 			var buf *bytes.Buffer
-		// 			BeforeEach(func() {
-		// 				buf = new(bytes.Buffer)
-		// 				klog.SetOutput(buf)
-		// 			})
-
-		// 			It("should warn if an instance is shutting-down", func() {
-		// 				instance.State = infrav1.InstanceStateShuttingDown
-		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-		// 				Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
-		// 				Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
-		// 			})
-
-		// 			It("should error when the instance is seen as terminated", func() {
-		// 				instance.State = infrav1.InstanceStateTerminated
-		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 				Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-		// 				Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
-		// 				Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
-		// 				Expect(ms.AWSMachinePool.Status.FailureMessage).To(PointTo(Equal("EC2 instance state \"terminated\" is unexpected")))
-		// 				expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceTerminatedReason}})
-		// 			})
-		// 		})
-		// 	})
-		// })
-
-		// Context("secrets management lifecycle", func() {
-		// 	var instance *infrav1.Instance
-		// 	secretPrefix := "test/secret"
-		// 	When("creating EC2 instances", func() {
-		// 		It("should leverage AWS Secrets Manager", func() {
-		// 			instance = &infrav1.Instance{
-		// 				ID:    "myMachine",
-		// 				State: infrav1.InstanceStatePending,
-		// 			}
-		// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
-		// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
-		// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(map[string][]string{"eid": {}}, nil).Times(1)
-		// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-
-		// 			ms.AWSMachinePool.ObjectMeta.Labels = map[string]string{
-		// 				clusterv1.MachineControlPlaneLabelName: "",
-		// 			}
-		// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 		})
-		// 	})
-
-		// 	When("there's a node ref and a secret ARN", func() {
-		// 		BeforeEach(func() {
-		// 			instance = &infrav1.Instance{
-		// 				ID: "myMachine",
-		// 			}
-
-		// 			ms.MachinePool.Status.NodeRef = &corev1.ObjectReference{
-		// 				Kind:       "Node",
-		// 				Name:       "myMachine",
-		// 				APIVersion: "v1",
-		// 			}
-
-		// 			ms.AWSMachinePool.Spec.CloudInit = infrav1.CloudInit{
-		// 				SecretPrefix: "secret",
-		// 				SecretCount:  5,
-		// 			}
-		// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
-		// 		})
-
-		// 		It("should delete the secret if the instance is running", func() {
-		// 			instance.State = infrav1.InstanceStateRunning
-		// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
-		// 				Return(map[string][]string{"eid": {}}, nil).Times(1)
-		// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-		// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 		})
-
-		// 		It("should delete the secret if the instance is terminated", func() {
-		// 			instance.State = infrav1.InstanceStateTerminated
-		// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 		})
-
-		// 		It("should delete the secret if the AWSMachine is deleted", func() {
-		// 			instance.State = infrav1.InstanceStateRunning
-		// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-		// 			_, _ = reconciler.reconcileDelete(ms, cs)
-		// 		})
-
-		// 		It("should delete the secret if the AWSMachine is in a failure condition", func() {
-		// 			ms.AWSMachinePool.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
-		// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-		// 			_, _ = reconciler.reconcileDelete(ms, cs)
-		// 		})
-		// 	})
-
-		// 	When("there's only a secret ARN and no node ref", func() {
-		// 		BeforeEach(func() {
-		// 			instance = &infrav1.Instance{
-		// 				ID: "myMachine",
-		// 			}
-		// 			ms.AWSMachinePool.Spec.CloudInit = infrav1.CloudInit{
-		// 				SecretPrefix: "secret",
-		// 				SecretCount:  5,
-		// 			}
-		// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
-		// 		})
-
-		// 		It("should not delete the secret if the instance is running", func() {
-		// 			instance.State = infrav1.InstanceStateRunning
-		// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
-		// 				Return(map[string][]string{"eid": {}}, nil).Times(1)
-		// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-		// 			secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).MaxTimes(0)
-		// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 		})
-
-		// 		It("should delete the secret if the instance is terminated", func() {
-		// 			instance.State = infrav1.InstanceStateTerminated
-		// 			secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-		// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 		})
-
-		// 		It("should delete the secret if the AWSMachine is deleted", func() {
-		// 			instance.State = infrav1.InstanceStateRunning
-		// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-		// 			_, _ = reconciler.reconcileDelete(ms, cs)
-		// 		})
-
-		// 		It("should delete the secret if the AWSMachine is in a failure condition", func() {
-		// 			ms.AWSMachinePool.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
-		// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-		// 			_, _ = reconciler.reconcileDelete(ms, cs)
-		// 		})
-		// 	})
-
-		// 	When("there is an intermittent connection issue and no secret could be stored", func() {
-		// 		BeforeEach(func() {
-		// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
-		// 		})
-		// 		It("should error if secret could not be created", func() {
-		// 			_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
-		// 			Expect(err).ToNot(BeNil())
-		// 			Expect(err.Error()).To(ContainSubstring("connection error"))
-		// 			Expect(ms.GetSecretPrefix()).To(Equal(""))
-		// 			Expect(ms.GetSecretCount()).To(Equal(int32(0)))
-		// 		})
-
-		// 		It("should update prefix and count on successful creation", func() {
-		// 			instance = &infrav1.Instance{
-		// 				ID: "myMachine",
-		// 			}
-		// 			instance.State = infrav1.InstanceStatePending
-		// 			secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(secretPrefix, int32(1), nil).Times(1)
-		// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
-		// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(map[string][]string{"eid": {}}, nil).Times(1)
-		// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-
-		// 			_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
-
-		// 			Expect(err).To(BeNil())
-		// 			Expect(ms.GetSecretPrefix()).To(Equal(secretPrefix))
-		// 			Expect(ms.GetSecretCount()).To(Equal(int32(1)))
-		// 		})
-		// 	})
-		// })
-
-		// Context("deleting an AWSMachine", func() {
-		// 	BeforeEach(func() {
-		// 		ms.AWSMachinePool.Finalizers = []string{
-		// 			infrav1.MachinePoolFinalizer,
-		// 			metav1.FinalizerDeleteDependents,
-		// 		}
-		// 	})
-
-		// 	It("should exit immediately on an error state", func() {
-		// 		expectedErr := errors.New("no connection available ")
-		// 		ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, expectedErr).AnyTimes()
-
-		// 		_, err := reconciler.reconcileDelete(ms, cs)
-		// 		Expect(errors.Cause(err)).To(MatchError(expectedErr))
-		// 	})
-
-		// 	It("should log and remove finalizer when no machine exists", func() {
-		// 		ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil)
-
-		// 		buf := new(bytes.Buffer)
-		// 		klog.SetOutput(buf)
-
-		// 		_, err := reconciler.reconcileDelete(ms, cs)
-		// 		Expect(err).To(BeNil())
-		// 		Expect(buf.String()).To(ContainSubstring("Unable to locate EC2 instance by ID or tags"))
-		// 		Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
-		// 		Eventually(recorder.Events).Should(Receive(ContainSubstring("NoInstanceFound")))
-		// 	})
-
-		// 	It("should ignore instances in shutting down state", func() {
-		// 		ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{
-		// 			State: infrav1.InstanceStateShuttingDown,
-		// 		}, nil)
-
-		// 		buf := new(bytes.Buffer)
-		// 		klog.SetOutput(buf)
-
-		// 		_, err := reconciler.reconcileDelete(ms, cs)
-		// 		Expect(err).To(BeNil())
-		// 		Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
-		// 		Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
-		// 	})
-
-		// 	It("should ignore instances in terminated down state", func() {
-		// 		ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{
-		// 			State: infrav1.InstanceStateTerminated,
-		// 		}, nil)
-
-		// 		buf := new(bytes.Buffer)
-		// 		klog.SetOutput(buf)
-
-		// 		_, err := reconciler.reconcileDelete(ms, cs)
-		// 		Expect(err).To(BeNil())
-		// 		Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
-		// 		Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
-		// 	})
-
-		// 	Context("Instance not shutting down yet", func() {
-		// 		id := "aws:////myid"
-
-		// 		BeforeEach(func() {
-		// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{ID: id}, nil)
-		// 		})
-
-		// 		It("should return an error when the instance can't be terminated", func() {
-		// 			expected := errors.New("can't reach AWS to terminate machine")
-		// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(expected)
-
-		// 			buf := new(bytes.Buffer)
-		// 			klog.SetOutput(buf)
-
-		// 			_, err := reconciler.reconcileDelete(ms, cs)
-		// 			Expect(errors.Cause(err)).To(MatchError(expected))
-		// 			Expect(buf.String()).To(ContainSubstring("Terminating EC2 instance"))
-		// 			Eventually(recorder.Events).Should(Receive(ContainSubstring("FailedTerminate")))
-		// 		})
-
-		// 		When("instance can be shut down", func() {
-		// 			BeforeEach(func() {
-		// 				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil)
-		// 			})
-
-		// 			When("there are network interfaces", func() {
-		// 				BeforeEach(func() {
-		// 					ms.AWSMachinePool.Spec.NetworkInterfaces = []string{
-		// 						"eth0",
-		// 						"eth1",
-		// 					}
-		// 				})
-
-		// 				It("should error when it can't retrieve security groups", func() {
-		// 					expected := errors.New("can't reach AWS to list security groups")
-		// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return(nil, expected)
-
-		// 					_, err := reconciler.reconcileDelete(ms, cs)
-		// 					Expect(errors.Cause(err)).To(MatchError(expected))
-		// 				})
-
-		// 				It("should error when it can't detach a security group from an interface", func() {
-		// 					expected := errors.New("can't reach AWS to detach security group")
-		// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{"sg0", "sg1"}, nil)
-		// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(gomock.Any(), gomock.Any()).Return(expected)
-
-		// 					_, err := reconciler.reconcileDelete(ms, cs)
-		// 					Expect(errors.Cause(err)).To(MatchError(expected))
-		// 				})
-
-		// 				It("should detach all combinations of network interfaces", func() {
-		// 					groups := []string{"sg0", "sg1"}
-		// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{"sg0", "sg1"}, nil)
-		// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(groups, "eth0").Return(nil)
-		// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(groups, "eth1").Return(nil)
-
-		// 					_, err := reconciler.reconcileDelete(ms, cs)
-		// 					Expect(err).To(BeNil())
-		// 				})
-		// 			})
-
-		// 			It("should remove security groups", func() {
-		// 				_, err := reconciler.reconcileDelete(ms, cs)
-		// 				Expect(err).To(BeNil())
-		// 				Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
-		// 			})
-		// })
-		// })
+		When("ASG creation succeeds", func() {
+			var asg *expinfrav1.AutoScalingGroup
+			BeforeEach(func() {
+				asg = &expinfrav1.AutoScalingGroup{
+					ID: "myMachine",
+				}
+				asg.State = expinfrav1.ASGStatePending
+
+				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil)
+				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(asg, nil)
+			})
+
+			Context("instance security group errors", func() {
+				BeforeEach(func() {
+					ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(nil, errors.New("stop here"))
+				})
+
+				It("should set attributes after creating an instance", func() {
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					// Expect(ms.AWSMachinePool.Spec.ProviderID).To(PointTo(Equal("aws:////myMachine")))
+					Expect(ms.AWSMachinePool.Annotations).To(Equal(map[string]string{"cluster-api-provider-aws": "true"}))
+				})
+
+				Context("with captured logging", func() {
+					var buf *bytes.Buffer
+
+					BeforeEach(func() {
+						buf = new(bytes.Buffer)
+						klog.SetOutput(buf)
+					})
+
+					It("should set ASG to pending", func() {
+						asg.State = expinfrav1.ASGStatePending
+						_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+						Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(infrav1.InstanceStatePending)))
+						Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
+						Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+						expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.InstanceNotReadyReason}})
+					})
+
+					It("should set instance to running", func() {
+						asg.State = expinfrav1.ASGStatePending
+						_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+						Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(infrav1.InstanceStateRunning)))
+						Expect(ms.AWSMachinePool.Status.Ready).To(Equal(true))
+						Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+						expectConditions(ms.AWSMachinePool, []conditionAssertion{
+							{conditionType: infrav1.InstanceReadyCondition, status: corev1.ConditionTrue},
+						})
+					})
+				})
+			})
+
+			Context("New ASG state", func() {
+				It("should error when the instance state is a new unseen one", func() {
+					buf := new(bytes.Buffer)
+					klog.SetOutput(buf)
+					asg.State = "NewAWSMachinePoolState"
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
+					Expect(buf.String()).To(ContainSubstring(("EC2 instance state is undefined")))
+					Eventually(recorder.Events).Should(Receive(ContainSubstring("InstanceUnhandledState")))
+					Expect(ms.AWSMachinePool.Status.FailureMessage).To(PointTo(Equal("EC2 instance state \"NewAWSMachineState\" is undefined")))
+					expectConditions(ms.AWSMachinePool, []conditionAssertion{{conditionType: infrav1.InstanceReadyCondition, status: corev1.ConditionUnknown}})
+				})
+			})
+
+			Context("Security Groups succeed", func() {
+				BeforeEach(func() {
+					ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
+						Return(map[string][]string{"eid": {}}, nil)
+					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil)
+				})
+
+				It("should reconcile security groups", func() {
+					ms.AWSMachinePool.Spec.AdditionalSecurityGroups = []infrav1.AWSResourceReference{
+						{
+							ID: pointer.StringPtr("sg-2345"),
+						},
+					}
+					// ms.AWSMachine.Spec.AdditionalSecurityGroups = []infrav1
+					ec2Svc.EXPECT().UpdateInstanceSecurityGroups(asg.ID, []string{"sg-2345"})
+
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					expectConditions(ms.AWSMachinePool, []conditionAssertion{{conditionType: infrav1.SecurityGroupsReadyCondition, status: corev1.ConditionTrue}})
+				})
+
+				It("should not tag anything if there's not tags", func() {
+					ec2Svc.EXPECT().UpdateInstanceSecurityGroups(gomock.Any(), gomock.Any()).Times(0)
+					if _, err := reconciler.reconcileNormal(context.Background(), ms, cs); err != nil {
+						_ = fmt.Errorf("reconcileNormal reutrned an error during test")
+					}
+				})
+
+				It("should tag instances from machine and cluster tags", func() {
+					ms.AWSMachinePool.Spec.AdditionalTags = infrav1.Tags{"kind": "alicorn"}
+					ms.AWSCluster.Spec.AdditionalTags = infrav1.Tags{"colour": "lavender"}
+
+					ec2Svc.EXPECT().UpdateResourceTags(
+						PointsTo("myMachine"),
+						map[string]string{
+							"kind":   "alicorn",
+							"colour": "lavender",
+						},
+						map[string]string{},
+					).Return(nil)
+
+					_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+					Expect(err).To(BeNil())
+				})
+			})
+
+			When("temporarily stopping then starting the AWSMachine", func() {
+				var buf *bytes.Buffer
+				BeforeEach(func() {
+					buf = new(bytes.Buffer)
+					klog.SetOutput(buf)
+					ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
+						Return(map[string][]string{"eid": {}}, nil).Times(1)
+					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
+				})
+
+				It("should set instance to stopping and unready", func() {
+					asg.State = expinfrav1.ASGStateStopping
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(expinfrav1.ASGStateStopping)))
+					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
+					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+					expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceStoppedReason}})
+				})
+
+				It("should then set instance to stopped and not ready", func() {
+					asg.State = expinfrav1.ASGStateStopped
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(infrav1.InstanceStateStopped)))
+					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
+					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+					expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceStoppedReason}})
+				})
+
+				It("should then set instance to running and ready once it is restarted", func() {
+					asg.State = expinfrav1.ASGStateRunning
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(expinfrav1.ASGStateRunning)))
+					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(true))
+					Expect(buf.String()).To(ContainSubstring(("ASG state changed")))
+				})
+			})
+
+			When("deleting the AWSMachinePool outside of Kubernetes", func() {
+				var buf *bytes.Buffer
+				BeforeEach(func() {
+					buf = new(bytes.Buffer)
+					klog.SetOutput(buf)
+				})
+
+				It("should warn if an instance is shutting-down", func() {
+					asg.State = expinfrav1.ASGStateShuttingDown
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
+					Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
+					Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
+				})
+
+				It("should error when the instance is seen as terminated", func() {
+					asg.State = expinfrav1.ASGStateTerminated
+					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
+					Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
+					Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
+					Expect(ms.AWSMachinePool.Status.FailureMessage).To(PointTo(Equal("EC2 instance state \"terminated\" is unexpected")))
+					expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceTerminatedReason}})
+				})
+			})
+		})
 	})
+
+	// Context("secrets management lifecycle", func() {
+	// 	var instance *infrav1.Instance
+	// 	secretPrefix := "test/secret"
+	// 	When("creating EC2 instances", func() {
+	// 		It("should leverage AWS Secrets Manager", func() {
+	// 			instance = &infrav1.Instance{
+	// 				ID:    "myMachine",
+	// 				State: infrav1.InstanceStatePending,
+	// 			}
+	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
+	// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
+	// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(map[string][]string{"eid": {}}, nil).Times(1)
+	// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
+
+	// 			ms.AWSMachinePool.ObjectMeta.Labels = map[string]string{
+	// 				clusterv1.MachineControlPlaneLabelName: "",
+	// 			}
+	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+	// 		})
+	// 	})
+
+	// 	When("there's a node ref and a secret ARN", func() {
+	// 		BeforeEach(func() {
+	// 			instance = &infrav1.Instance{
+	// 				ID: "myMachine",
+	// 			}
+
+	// 			ms.MachinePool.Status.NodeRef = &corev1.ObjectReference{
+	// 				Kind:       "Node",
+	// 				Name:       "myMachine",
+	// 				APIVersion: "v1",
+	// 			}
+
+	// 			ms.AWSMachinePool.Spec.CloudInit = infrav1.CloudInit{
+	// 				SecretPrefix: "secret",
+	// 				SecretCount:  5,
+	// 			}
+	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
+	// 		})
+
+	// 		It("should delete the secret if the instance is running", func() {
+	// 			instance.State = infrav1.InstanceStateRunning
+	// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
+	// 				Return(map[string][]string{"eid": {}}, nil).Times(1)
+	// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
+	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+	// 		})
+
+	// 		It("should delete the secret if the instance is terminated", func() {
+	// 			instance.State = infrav1.InstanceStateTerminated
+	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+	// 		})
+
+	// 		It("should delete the secret if the AWSMachine is deleted", func() {
+	// 			instance.State = infrav1.InstanceStateRunning
+	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+	// 			_, _ = reconciler.reconcileDelete(ms, cs)
+	// 		})
+
+	// 		It("should delete the secret if the AWSMachine is in a failure condition", func() {
+	// 			ms.AWSMachinePool.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
+	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+	// 			_, _ = reconciler.reconcileDelete(ms, cs)
+	// 		})
+	// 	})
+
+	// 	When("there's only a secret ARN and no node ref", func() {
+	// 		BeforeEach(func() {
+	// 			instance = &infrav1.Instance{
+	// 				ID: "myMachine",
+	// 			}
+	// 			ms.AWSMachinePool.Spec.CloudInit = infrav1.CloudInit{
+	// 				SecretPrefix: "secret",
+	// 				SecretCount:  5,
+	// 			}
+	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
+	// 		})
+
+	// 		It("should not delete the secret if the instance is running", func() {
+	// 			instance.State = infrav1.InstanceStateRunning
+	// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
+	// 				Return(map[string][]string{"eid": {}}, nil).Times(1)
+	// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
+	// 			secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).MaxTimes(0)
+	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+	// 		})
+
+	// 		It("should delete the secret if the instance is terminated", func() {
+	// 			instance.State = infrav1.InstanceStateTerminated
+	// 			secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+	// 		})
+
+	// 		It("should delete the secret if the AWSMachine is deleted", func() {
+	// 			instance.State = infrav1.InstanceStateRunning
+	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+	// 			_, _ = reconciler.reconcileDelete(ms, cs)
+	// 		})
+
+	// 		It("should delete the secret if the AWSMachine is in a failure condition", func() {
+	// 			ms.AWSMachinePool.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
+	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
+	// 			_, _ = reconciler.reconcileDelete(ms, cs)
+	// 		})
+	// 	})
+
+	// 	When("there is an intermittent connection issue and no secret could be stored", func() {
+	// 		BeforeEach(func() {
+	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
+	// 		})
+	// 		It("should error if secret could not be created", func() {
+	// 			_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+	// 			Expect(err).ToNot(BeNil())
+	// 			Expect(err.Error()).To(ContainSubstring("connection error"))
+	// 			Expect(ms.GetSecretPrefix()).To(Equal(""))
+	// 			Expect(ms.GetSecretCount()).To(Equal(int32(0)))
+	// 		})
+
+	// 		It("should update prefix and count on successful creation", func() {
+	// 			instance = &infrav1.Instance{
+	// 				ID: "myMachine",
+	// 			}
+	// 			instance.State = infrav1.InstanceStatePending
+	// 			secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(secretPrefix, int32(1), nil).Times(1)
+	// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
+	// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(map[string][]string{"eid": {}}, nil).Times(1)
+	// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
+
+	// 			_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+
+	// 			Expect(err).To(BeNil())
+	// 			Expect(ms.GetSecretPrefix()).To(Equal(secretPrefix))
+	// 			Expect(ms.GetSecretCount()).To(Equal(int32(1)))
+	// 		})
+	// 	})
+	// })
+
+	// Context("deleting an AWSMachine", func() {
+	// 	BeforeEach(func() {
+	// 		ms.AWSMachinePool.Finalizers = []string{
+	// 			infrav1.MachinePoolFinalizer,
+	// 			metav1.FinalizerDeleteDependents,
+	// 		}
+	// 	})
+
+	// 	It("should exit immediately on an error state", func() {
+	// 		expectedErr := errors.New("no connection available ")
+	// 		ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+
+	// 		_, err := reconciler.reconcileDelete(ms, cs)
+	// 		Expect(errors.Cause(err)).To(MatchError(expectedErr))
+	// 	})
+
+	// 	It("should log and remove finalizer when no machine exists", func() {
+	// 		ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil)
+
+	// 		buf := new(bytes.Buffer)
+	// 		klog.SetOutput(buf)
+
+	// 		_, err := reconciler.reconcileDelete(ms, cs)
+	// 		Expect(err).To(BeNil())
+	// 		Expect(buf.String()).To(ContainSubstring("Unable to locate EC2 instance by ID or tags"))
+	// 		Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
+	// 		Eventually(recorder.Events).Should(Receive(ContainSubstring("NoInstanceFound")))
+	// 	})
+
+	// 	It("should ignore instances in shutting down state", func() {
+	// 		ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{
+	// 			State: infrav1.InstanceStateShuttingDown,
+	// 		}, nil)
+
+	// 		buf := new(bytes.Buffer)
+	// 		klog.SetOutput(buf)
+
+	// 		_, err := reconciler.reconcileDelete(ms, cs)
+	// 		Expect(err).To(BeNil())
+	// 		Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
+	// 		Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
+	// 	})
+
+	// 	It("should ignore instances in terminated down state", func() {
+	// 		ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{
+	// 			State: infrav1.InstanceStateTerminated,
+	// 		}, nil)
+
+	// 		buf := new(bytes.Buffer)
+	// 		klog.SetOutput(buf)
+
+	// 		_, err := reconciler.reconcileDelete(ms, cs)
+	// 		Expect(err).To(BeNil())
+	// 		Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
+	// 		Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
+	// 	})
+
+	// 	Context("Instance not shutting down yet", func() {
+	// 		id := "aws:////myid"
+
+	// 		BeforeEach(func() {
+	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{ID: id}, nil)
+	// 		})
+
+	// 		It("should return an error when the instance can't be terminated", func() {
+	// 			expected := errors.New("can't reach AWS to terminate machine")
+	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(expected)
+
+	// 			buf := new(bytes.Buffer)
+	// 			klog.SetOutput(buf)
+
+	// 			_, err := reconciler.reconcileDelete(ms, cs)
+	// 			Expect(errors.Cause(err)).To(MatchError(expected))
+	// 			Expect(buf.String()).To(ContainSubstring("Terminating EC2 instance"))
+	// 			Eventually(recorder.Events).Should(Receive(ContainSubstring("FailedTerminate")))
+	// 		})
+
+	// 		When("instance can be shut down", func() {
+	// 			BeforeEach(func() {
+	// 				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil)
+	// 			})
+
+	// 			When("there are network interfaces", func() {
+	// 				BeforeEach(func() {
+	// 					ms.AWSMachinePool.Spec.NetworkInterfaces = []string{
+	// 						"eth0",
+	// 						"eth1",
+	// 					}
+	// 				})
+
+	// 				It("should error when it can't retrieve security groups", func() {
+	// 					expected := errors.New("can't reach AWS to list security groups")
+	// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return(nil, expected)
+
+	// 					_, err := reconciler.reconcileDelete(ms, cs)
+	// 					Expect(errors.Cause(err)).To(MatchError(expected))
+	// 				})
+
+	// 				It("should error when it can't detach a security group from an interface", func() {
+	// 					expected := errors.New("can't reach AWS to detach security group")
+	// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{"sg0", "sg1"}, nil)
+	// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(gomock.Any(), gomock.Any()).Return(expected)
+
+	// 					_, err := reconciler.reconcileDelete(ms, cs)
+	// 					Expect(errors.Cause(err)).To(MatchError(expected))
+	// 				})
+
+	// 				It("should detach all combinations of network interfaces", func() {
+	// 					groups := []string{"sg0", "sg1"}
+	// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{"sg0", "sg1"}, nil)
+	// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(groups, "eth0").Return(nil)
+	// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(groups, "eth1").Return(nil)
+
+	// 					_, err := reconciler.reconcileDelete(ms, cs)
+	// 					Expect(err).To(BeNil())
+	// 				})
+	// 			})
+
+	// 			It("should remove security groups", func() {
+	// 				_, err := reconciler.reconcileDelete(ms, cs)
+	// 				Expect(err).To(BeNil())
+	// 				Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
+	// 			})
+	// })
+	// })
 })
+
+// })
 
 func PointsTo(s string) gomock.Matcher {
 	return &pointsTo{

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -1,0 +1,469 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"bytes"
+	"context"
+	"flag"
+	"fmt"
+
+	"github.com/golang/mock/gomock"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog"
+	"k8s.io/utils/pointer"
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/scope"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services"
+	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/mock_services"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capierrors "sigs.k8s.io/cluster-api/errors"
+	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
+	"sigs.k8s.io/cluster-api/util/conditions"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("AWSMachinePoolReconciler", func() {
+	var (
+		reconciler AWSMachinePoolReconciler
+		cs         *scope.ClusterScope
+		ms         *scope.MachinePoolScope
+		mockCtrl   *gomock.Controller
+		ec2Svc     *mock_services.MockEC2MachineInterface
+		asgSvc     *mock_services.MockASGInterface
+		recorder   *record.FakeRecorder
+	)
+
+	BeforeEach(func() {
+		var err error //TODO: check out LogToOutput
+
+		if err := flag.Set("logtostderr", "false"); err != nil {
+			_ = fmt.Errorf("Error setting logtostderr flag")
+		}
+		if err := flag.Set("v", "2"); err != nil {
+			_ = fmt.Errorf("Error setting v flag")
+		}
+
+		klog.SetOutput(GinkgoWriter)
+
+		awsMachinePool := &expinfrav1.AWSMachinePool{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test",
+			},
+			Spec: expinfrav1.AWSMachinePoolSpec{},
+		}
+
+		secret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bootstrap-data",
+			},
+			Data: map[string][]byte{
+				"value": []byte("shell-script"),
+			},
+		}
+
+		ms, err = scope.NewMachinePoolScope(
+			scope.MachinePoolScopeParams{
+				Client: fake.NewFakeClient([]runtime.Object{awsMachinePool, secret}...),
+				Cluster: &clusterv1.Cluster{
+					Status: clusterv1.ClusterStatus{
+						InfrastructureReady: true,
+					},
+				},
+				MachinePool: &expclusterv1.MachinePool{
+					Spec: expclusterv1.MachinePoolSpec{
+						Template: clusterv1.MachineTemplateSpec{
+							Spec: clusterv1.MachineSpec{
+								Bootstrap: clusterv1.Bootstrap{
+									DataSecretName: pointer.StringPtr("bootstrap-data"),
+								},
+							},
+						},
+					},
+				},
+				AWSCluster:     &infrav1.AWSCluster{},
+				AWSMachinePool: awsMachinePool,
+			},
+		)
+		Expect(err).To(BeNil())
+
+		cs, err = scope.NewClusterScope(
+			scope.ClusterScopeParams{
+				Cluster:    &clusterv1.Cluster{},
+				AWSCluster: &infrav1.AWSCluster{},
+			},
+		)
+		Expect(err).To(BeNil())
+
+		mockCtrl = gomock.NewController(GinkgoT())
+		ec2Svc = mock_services.NewMockEC2MachineInterface(mockCtrl)
+		asgSvc = mock_services.NewMockASGInterface(mockCtrl)
+
+		// If the test hangs for 9 minutes, increase the value here to the number of events during a reconciliation loop
+		recorder = record.NewFakeRecorder(2)
+
+		reconciler = AWSMachinePoolReconciler{
+			ec2ServiceFactory: func(*scope.ClusterScope) services.EC2MachineInterface {
+				return ec2Svc
+			},
+			asgServiceFactory: func(*scope.ClusterScope) services.ASGInterface {
+				return asgSvc
+			},
+			Recorder: recorder,
+		}
+	})
+	AfterEach(func() {
+		mockCtrl.Finish()
+	})
+
+	Context("Reconciling an AWSMachinePool", func() {
+		When("we can't reach amazon", func() {
+			expectedErr := errors.New("no connection available ")
+
+			BeforeEach(func() {
+				//ec2Svc.EXPECT().DeleteLaunchTemplate(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+			})
+
+			It("should exit immediately on an error state", func() {
+				er := capierrors.CreateMachineError
+				ms.AWSMachinePool.Status.FailureReason = &er
+				ms.AWSMachinePool.Status.FailureMessage = pointer.StringPtr("Couldn't create machine pool")
+
+				buf := new(bytes.Buffer)
+				klog.SetOutput(buf)
+
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+				Expect(buf).To(ContainSubstring("Error state detected, skipping reconciliation"))
+			})
+
+			It("should add our finalizer to the machinepool", func() {
+				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+
+				Expect(ms.AWSMachinePool.Finalizers).To(ContainElement(infrav1.MachineFinalizer))
+			})
+
+			It("should exit immediately if cluster infra isn't ready", func() {
+				ms.Cluster.Status.InfrastructureReady = false
+
+				buf := new(bytes.Buffer)
+				klog.SetOutput(buf)
+
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				Expect(err).To(BeNil())
+				Expect(buf.String()).To(ContainSubstring("Cluster infrastructure is not ready yet"))
+				expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForClusterInfrastructureReason}})
+			})
+
+			It("should exit immediately if bootstrap data secret reference isn't available", func() {
+				ms.MachinePool.Spec.Template.Spec.Bootstrap.DataSecretName = nil
+				buf := new(bytes.Buffer)
+				klog.SetOutput(buf)
+
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+
+				Expect(err).To(BeNil())
+				Expect(buf.String()).To(ContainSubstring("Bootstrap data secret reference is not yet available"))
+				expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForBootstrapDataReason}})
+			})
+
+			It("should return an error when we can't list instances by tags", func() {
+				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+				Expect(errors.Cause(err)).To(MatchError(expectedErr))
+			})
+		})
+
+		// When("there's a provider ID", func() {
+		// 	id := "aws:////myMachine"
+		// 	BeforeEach(func() {
+		// 		_, err := noderefutil.NewProviderID(id)
+		// 		Expect(err).To(BeNil())
+
+		// 		ms.AWSMachine.Spec.ProviderID = &id
+		// 	})
+
+		// 		It("it should look up by provider ID when one exists", func() {
+		// 			expectedErr := errors.New("no connection available ")
+		// 			ec2Svc.EXPECT().InstanceIfExists(PointsTo("myMachine")).Return(nil, expectedErr)
+
+		// 			_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 			Expect(errors.Cause(err)).To(MatchError(expectedErr))
+		// 		})
+
+		// 		It("should try to create a new machine if none exists", func() {
+		// 			expectedErr := errors.New("Invalid instance")
+		// 			ec2Svc.EXPECT().InstanceIfExists(gomock.Any()).Return(nil, nil)
+		// 			secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return("test", int32(1), nil).Times(1)
+		// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(nil, expectedErr)
+
+		// 			_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 			Expect(errors.Cause(err)).To(MatchError(expectedErr))
+		// 		})
+		// 	})
+
+		// 	When("instance creation succeeds", func() {
+		// 		var instance *infrav1.Instance
+		// 		BeforeEach(func() {
+		// 			instance = &infrav1.Instance{
+		// 				ID: "myMachine",
+		// 			}
+		// 			instance.State = infrav1.InstanceStatePending
+
+		// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil)
+		// 			secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return("test", int32(1), nil).Times(1)
+		// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil)
+		// 		})
+
+		// 		Context("instance security group errors", func() {
+		// 			BeforeEach(func() {
+		// 				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(nil, errors.New("stop here"))
+		// 			})
+
+		// 			It("should set attributes after creating an instance", func() {
+		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				Expect(ms.AWSMachine.Spec.ProviderID).To(PointTo(Equal("aws:////myMachine")))
+		// 				Expect(ms.AWSMachine.Annotations).To(Equal(map[string]string{"cluster-api-provider-aws": "true"}))
+		// 			})
+
+		// 			Context("with captured logging", func() {
+		// 				var buf *bytes.Buffer
+
+		// 				BeforeEach(func() {
+		// 					buf = new(bytes.Buffer)
+		// 					klog.SetOutput(buf)
+		// 				})
+
+		// 				It("should set instance to pending", func() {
+		// 					instance.State = infrav1.InstanceStatePending
+		// 					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 					Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStatePending)))
+		// 					Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
+		// 					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+		// 					expectConditions(ms.AWSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.InstanceNotReadyReason}})
+		// 				})
+
+		// 				It("should set instance to running", func() {
+		// 					instance.State = infrav1.InstanceStateRunning
+		// 					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 					Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateRunning)))
+		// 					Expect(ms.AWSMachine.Status.Ready).To(Equal(true))
+		// 					Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+		// 					expectConditions(ms.AWSMachine, []conditionAssertion{
+		// 						{conditionType: infrav1.InstanceReadyCondition, status: corev1.ConditionTrue},
+		// 					})
+		// 				})
+		// 			})
+		// 		})
+
+		// 		Context("New EC2 instance state", func() {
+		// 			It("should error when the instance state is a new unseen one", func() {
+		// 				buf := new(bytes.Buffer)
+		// 				klog.SetOutput(buf)
+		// 				instance.State = "NewAWSMachineState"
+		// 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
+		// 				Expect(buf.String()).To(ContainSubstring(("EC2 instance state is undefined")))
+		// 				Eventually(recorder.Events).Should(Receive(ContainSubstring("InstanceUnhandledState")))
+		// 				Expect(ms.AWSMachine.Status.FailureMessage).To(PointTo(Equal("EC2 instance state \"NewAWSMachineState\" is undefined")))
+		// 				expectConditions(ms.AWSMachine, []conditionAssertion{{conditionType: infrav1.InstanceReadyCondition, status: corev1.ConditionUnknown}})
+		// 			})
+		// 		})
+
+		// 		Context("Security Groups succeed", func() {
+		// 			BeforeEach(func() {
+		// 				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
+		// 					Return(map[string][]string{"eid": {}}, nil)
+		// 				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil)
+		// 			})
+
+		// 			It("should reconcile security groups", func() {
+		// 				ms.AWSMachine.Spec.AdditionalSecurityGroups = []infrav1.AWSResourceReference{
+		// 					{
+		// 						ID: pointer.StringPtr("sg-2345"),
+		// 					},
+		// 				}
+		// 				// ms.AWSMachine.Spec.AdditionalSecurityGroups = []infrav1
+		// 				ec2Svc.EXPECT().UpdateInstanceSecurityGroups(instance.ID, []string{"sg-2345"})
+
+		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				expectConditions(ms.AWSMachine, []conditionAssertion{{conditionType: infrav1.SecurityGroupsReadyCondition, status: corev1.ConditionTrue}})
+		// 			})
+
+		// 			It("should not tag anything if there's not tags", func() {
+		// 				ec2Svc.EXPECT().UpdateInstanceSecurityGroups(gomock.Any(), gomock.Any()).Times(0)
+		// 				if _, err := reconciler.reconcileNormal(context.Background(), ms, cs); err != nil {
+		// 					_ = fmt.Errorf("reconcileNormal reutrned an error during test")
+		// 				}
+		// 			})
+
+		// 			It("should tag instances from machine and cluster tags", func() {
+		// 				ms.AWSMachine.Spec.AdditionalTags = infrav1.Tags{"kind": "alicorn"}
+		// 				ms.AWSCluster.Spec.AdditionalTags = infrav1.Tags{"colour": "lavender"}
+
+		// 				ec2Svc.EXPECT().UpdateResourceTags(
+		// 					PointsTo("myMachine"),
+		// 					map[string]string{
+		// 						"kind":   "alicorn",
+		// 						"colour": "lavender",
+		// 					},
+		// 					map[string]string{},
+		// 				).Return(nil)
+
+		// 				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				Expect(err).To(BeNil())
+		// 			})
+		// 		})
+
+		// 		When("temporarily stopping then starting the AWSMachine", func() {
+		// 			var buf *bytes.Buffer
+		// 			BeforeEach(func() {
+		// 				buf = new(bytes.Buffer)
+		// 				klog.SetOutput(buf)
+		// 				ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
+		// 					Return(map[string][]string{"eid": {}}, nil).Times(1)
+		// 				ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
+		// 			})
+
+		// 			It("should set instance to stopping and unready", func() {
+		// 				instance.State = infrav1.InstanceStateStopping
+		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateStopping)))
+		// 				Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
+		// 				Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+		// 				expectConditions(ms.AWSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceStoppedReason}})
+		// 			})
+
+		// 			It("should then set instance to stopped and unready", func() {
+		// 				instance.State = infrav1.InstanceStateStopped
+		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateStopped)))
+		// 				Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
+		// 				Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+		// 				expectConditions(ms.AWSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceStoppedReason}})
+		// 			})
+
+		// 			It("should then set instance to running and ready once it is restarted", func() {
+		// 				instance.State = infrav1.InstanceStateRunning
+		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				Expect(ms.AWSMachine.Status.InstanceState).To(PointTo(Equal(infrav1.InstanceStateRunning)))
+		// 				Expect(ms.AWSMachine.Status.Ready).To(Equal(true))
+		// 				Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
+		// 			})
+		// 		})
+
+		// 		When("deleting the AWSMachine outside of Kubernetes", func() {
+		// 			var buf *bytes.Buffer
+		// 			BeforeEach(func() {
+		// 				buf = new(bytes.Buffer)
+		// 				klog.SetOutput(buf)
+		// 				secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
+		// 			})
+
+		// 			It("should warn if an instance is shutting-down", func() {
+		// 				instance.State = infrav1.InstanceStateShuttingDown
+		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
+		// 				Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
+		// 				Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
+		// 			})
+
+		// 			It("should error when the instance is seen as terminated", func() {
+		// 				instance.State = infrav1.InstanceStateTerminated
+		// 				_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
+		// 				Expect(ms.AWSMachine.Status.Ready).To(Equal(false))
+		// 				Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
+		// 				Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
+		// 				Expect(ms.AWSMachine.Status.FailureMessage).To(PointTo(Equal("EC2 instance state \"terminated\" is unexpected")))
+		// 				expectConditions(ms.AWSMachine, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceTerminatedReason}})
+		// 			})
+		// 		})
+		// 	})
+	})
+})
+
+// func TestAWSMachinePoolReconciler_getASGService(t *testing.T) {
+// 	type fields struct {
+// 		Client            client.Client
+// 		Log               logr.Logger
+// 		Recorder          record.EventRecorder
+// 		asgServiceFactory func(*scope.ClusterScope) services.ASGInterface
+// 		ec2ServiceFactory func(*scope.ClusterScope) services.EC2MachineInterface
+// 	}
+// 	type args struct {
+// 		scope *scope.ClusterScope
+// 	}
+// 	tests := []struct {
+// 		name   string
+// 		fields fields
+// 		args   args
+// 		want   services.ASGInterface
+// 	}{
+// 		{
+// 			name: "nil ASG service factory",
+// 			fields: fields{
+// 				asgServiceFactory: nil,
+// 			},
+// 			args: args{
+// 				scope: &scope.ClusterScope{},
+// 			},
+// 			want: ,
+// 		},
+// 	}
+
+// 	for _, tt := range tests {
+// 		t.Run(tt.name, func(t *testing.T) {
+// 			r := &AWSMachinePoolReconciler{
+// 				Client:            tt.fields.Client,
+// 				Log:               tt.fields.Log,
+// 				Recorder:          tt.fields.Recorder,
+// 				asgServiceFactory: tt.fields.asgServiceFactory,
+// 				ec2ServiceFactory: tt.fields.ec2ServiceFactory,
+// 			}
+// 			if got := r.getASGService(tt.args.scope); !reflect.DeepEqual(got, tt.want) {
+// 				t.Errorf("AWSMachinePoolReconciler.getASGService() = %v, want %v", got, tt.want)
+// 			}
+// 		})
+// 	}
+// }
+
+func expectConditions(m *expinfrav1.AWSMachinePool, expected []conditionAssertion) {
+	Expect(len(m.Status.Conditions)).To(BeNumerically(">=", len(expected)), "number of conditions")
+	for _, c := range expected {
+		actual := conditions.Get(m, c.conditionType)
+		Expect(actual).To(Not(BeNil()))
+		Expect(actual.Type).To(Equal(c.conditionType))
+		Expect(actual.Status).To(Equal(c.status))
+		Expect(actual.Severity).To(Equal(c.severity))
+		Expect(actual.Reason).To(Equal(c.reason))
+	}
+}
+
+type conditionAssertion struct {
+	conditionType clusterv1.ConditionType
+	status        corev1.ConditionStatus
+	severity      clusterv1.ConditionSeverity
+	reason        string
+}

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -143,7 +143,6 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			expectedErr := errors.New("no connection available ")
 
 			BeforeEach(func() {
-				// ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 			})
 

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -143,7 +143,7 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			expectedErr := errors.New("no connection available ")
 
 			BeforeEach(func() {
-				//ec2Svc.EXPECT().DeleteLaunchTemplate(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+				// ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, expectedErr).AnyTimes()
 			})
 

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -140,8 +140,6 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 	})
 
 	Context("Reconciling an AWSMachinePool", func() {
-		// var launchtemplate *expinfrav1.AWSLaunchTemplate
-
 		When("we can't reach amazon", func() {
 			expectedErr := errors.New("no connection available ")
 
@@ -191,11 +189,6 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 				Expect(buf.String()).To(ContainSubstring("Bootstrap data secret reference is not yet available"))
 				expectConditions(ms.AWSMachinePool, []conditionAssertion{{expinfrav1.ASGReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityInfo, infrav1.WaitingForBootstrapDataReason}})
 			})
-
-			It("should return an error when we can't list instances by tags", func() {
-				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
-				Expect(errors.Cause(err)).To(MatchError(expectedErr))
-			})
 		})
 
 		When("there's a provider ID", func() {
@@ -209,7 +202,8 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 
 			It("it should look up by provider ID when one exists", func() {
 				expectedErr := errors.New("no connection available ")
-				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, expectedErr)
+				var launchtemplate *expinfrav1.AWSLaunchTemplate
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(launchtemplate, expectedErr)
 				_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
 				Expect(errors.Cause(err)).To(MatchError(expectedErr))
 			})

--- a/exp/controllers/awsmachinepool_controller_test.go
+++ b/exp/controllers/awsmachinepool_controller_test.go
@@ -240,56 +240,21 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 				}
 				asg.State = expinfrav1.ASGStatePending
 
-				ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil)
-				ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(asg, nil)
+				ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil).AnyTimes()
+				ec2Svc.EXPECT().CreateLaunchTemplate(gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
+				asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, nil).AnyTimes()
+
+				// ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil)
+				// ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(asg, nil)
 			})
 
-			Context("instance security group errors", func() {
-				BeforeEach(func() {
-					ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(nil, errors.New("stop here"))
-				})
-
-				It("should set attributes after creating an instance", func() {
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-					Expect(ms.AWSMachinePool.Spec.ProviderID).To(PointTo(Equal("aws:////myMachine")))
-					Expect(ms.AWSMachinePool.Annotations).To(Equal(map[string]string{"cluster-api-provider-aws": "true"}))
-				})
-
-				Context("with captured logging", func() {
-					var buf *bytes.Buffer
-
-					BeforeEach(func() {
-						buf = new(bytes.Buffer)
-						klog.SetOutput(buf)
-					})
-
-					It("should set ASG to pending", func() {
-						asg.State = expinfrav1.ASGStatePending
-						_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-						Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(infrav1.InstanceStatePending)))
-						Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-						Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-						expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityWarning, infrav1.InstanceNotReadyReason}})
-					})
-
-					It("should set instance to running", func() {
-						asg.State = expinfrav1.ASGStatePending
-						_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-						Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(infrav1.InstanceStateRunning)))
-						Expect(ms.AWSMachinePool.Status.Ready).To(Equal(true))
-						Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-						expectConditions(ms.AWSMachinePool, []conditionAssertion{
-							{conditionType: infrav1.InstanceReadyCondition, status: corev1.ConditionTrue},
-						})
-					})
-				})
-			})
-
+			//TODO: make this pass in machinepool_controller.go
 			Context("New ASG state", func() {
 				It("should error when the instance state is a new unseen one", func() {
 					buf := new(bytes.Buffer)
 					klog.SetOutput(buf)
 					asg.State = "NewAWSMachinePoolState"
+					asgSvc.EXPECT().CreateASG(gomock.Any()).Return(asg, nil)
 					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
 					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
 					Expect(buf.String()).To(ContainSubstring(("ASG state is undefined")))
@@ -298,255 +263,8 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 					expectConditions(ms.AWSMachinePool, []conditionAssertion{{conditionType: expinfrav1.ASGReadyCondition, status: corev1.ConditionUnknown}})
 				})
 			})
-
-			Context("Security Groups succeed", func() {
-				BeforeEach(func() {
-					ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
-						Return(map[string][]string{"eid": {}}, nil)
-					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil)
-				})
-
-				It("should reconcile security groups", func() {
-					ms.AWSMachinePool.Spec.AdditionalSecurityGroups = []infrav1.AWSResourceReference{
-						{
-							ID: pointer.StringPtr("sg-2345"),
-						},
-					}
-					// ms.AWSMachine.Spec.AdditionalSecurityGroups = []infrav1
-					ec2Svc.EXPECT().UpdateInstanceSecurityGroups(asg.ID, []string{"sg-2345"})
-
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-					expectConditions(ms.AWSMachinePool, []conditionAssertion{{conditionType: infrav1.SecurityGroupsReadyCondition, status: corev1.ConditionTrue}})
-				})
-
-				It("should not tag anything if there's not tags", func() {
-					ec2Svc.EXPECT().UpdateInstanceSecurityGroups(gomock.Any(), gomock.Any()).Times(0)
-					if _, err := reconciler.reconcileNormal(context.Background(), ms, cs); err != nil {
-						_ = fmt.Errorf("reconcileNormal reutrned an error during test")
-					}
-				})
-
-				It("should tag instances from machine and cluster tags", func() {
-					ms.AWSMachinePool.Spec.AdditionalTags = infrav1.Tags{"kind": "alicorn"}
-					ms.AWSCluster.Spec.AdditionalTags = infrav1.Tags{"colour": "lavender"}
-
-					ec2Svc.EXPECT().UpdateResourceTags(
-						PointsTo("myMachine"),
-						map[string]string{
-							"kind":   "alicorn",
-							"colour": "lavender",
-						},
-						map[string]string{},
-					).Return(nil)
-
-					_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
-					Expect(err).To(BeNil())
-				})
-			})
-
-			// Not relevant
-			// When("temporarily stopping then starting the AWSMachinePool", func() {
-			// 	var buf *bytes.Buffer
-			// 	BeforeEach(func() {
-			// 		buf = new(bytes.Buffer)
-			// 		klog.SetOutput(buf)
-			// 		ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
-			// 			Return(map[string][]string{"eid": {}}, nil).Times(1)
-			// 		ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-			// 	})
-
-			// 	It("should set instance to stopping and unready", func() {
-			// 		asg.State = expinfrav1.ASGStateStopping
-			// 		_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-			// 		Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(expinfrav1.ASGStateStopping)))
-			// 		Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-			// 		Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-			// 		expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceStoppedReason}})
-			// 	})
-
-			// 	It("should then set instance to stopped and not ready", func() {
-			// 		asg.State = expinfrav1.ASGStateStopped
-			// 		_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-			// 		Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(infrav1.InstanceStateStopped)))
-			// 		Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-			// 		Expect(buf.String()).To(ContainSubstring(("EC2 instance state changed")))
-			// 		expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceStoppedReason}})
-			// 	})
-
-			// 	It("should then set instance to running and ready once it is restarted", func() {
-			// 		asg.State = expinfrav1.ASGStateRunning
-			// 		_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-			// 		Expect(ms.AWSMachinePool.Status.ASGState).To(PointTo(Equal(expinfrav1.ASGStateRunning)))
-			// 		Expect(ms.AWSMachinePool.Status.Ready).To(Equal(true))
-			// 		Expect(buf.String()).To(ContainSubstring(("ASG state changed")))
-			// 	})
-			// })
-
-			When("deleting the AWSMachinePool outside of Kubernetes", func() {
-				var buf *bytes.Buffer
-				BeforeEach(func() {
-					buf = new(bytes.Buffer)
-					klog.SetOutput(buf)
-				})
-
-				It("should warn if an instance is deleting", func() {
-					asg.State = expinfrav1.ASGStateShuttingDown
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-					Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
-					Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
-				})
-
-				It("should error when the ASG is seen as terminated", func() {
-					asg.State = expinfrav1.ASGStateTerminated
-					_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-					Expect(ms.AWSMachinePool.Status.Ready).To(Equal(false))
-					Expect(buf.String()).To(ContainSubstring(("Unexpected EC2 instance termination")))
-					Eventually(recorder.Events).Should(Receive(ContainSubstring("UnexpectedTermination")))
-					Expect(ms.AWSMachinePool.Status.FailureMessage).To(PointTo(Equal("EC2 instance state \"terminated\" is unexpected")))
-					expectConditions(ms.AWSMachinePool, []conditionAssertion{{infrav1.InstanceReadyCondition, corev1.ConditionFalse, clusterv1.ConditionSeverityError, infrav1.InstanceTerminatedReason}})
-				})
-			})
 		})
 	})
-
-	// TODO: Not relevant remove?
-	// Context("secrets management lifecycle", func() {
-	// 	var instance *infrav1.Instance
-	// 	secretPrefix := "test/secret"
-	// 	When("creating EC2 instances", func() {
-	// 		It("should leverage AWS Secrets Manager", func() {
-	// 			instance = &infrav1.Instance{
-	// 				ID:    "myMachine",
-	// 				State: infrav1.InstanceStatePending,
-	// 			}
-	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
-	// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
-	// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(map[string][]string{"eid": {}}, nil).Times(1)
-	// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-
-	// 			ms.AWSMachinePool.ObjectMeta.Labels = map[string]string{
-	// 				clusterv1.MachineControlPlaneLabelName: "",
-	// 			}
-	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-	// 		})
-	// 	})
-
-	// 	When("there's a node ref and a secret ARN", func() {
-	// 		BeforeEach(func() {
-	// 			instance = &infrav1.Instance{
-	// 				ID: "myMachine",
-	// 			}
-
-	// 			ms.MachinePool.Status.NodeRef = &corev1.ObjectReference{
-	// 				Kind:       "Node",
-	// 				Name:       "myMachine",
-	// 				APIVersion: "v1",
-	// 			}
-
-	// 			ms.AWSMachinePool.Spec.CloudInit = infrav1.CloudInit{
-	// 				SecretPrefix: "secret",
-	// 				SecretCount:  5,
-	// 			}
-	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
-	// 		})
-
-	// 		It("should delete the secret if the instance is running", func() {
-	// 			instance.State = infrav1.InstanceStateRunning
-	// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
-	// 				Return(map[string][]string{"eid": {}}, nil).Times(1)
-	// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-	// 		})
-
-	// 		It("should delete the secret if the instance is terminated", func() {
-	// 			instance.State = infrav1.InstanceStateTerminated
-	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-	// 		})
-
-	// 		It("should delete the secret if the AWSMachine is deleted", func() {
-	// 			instance.State = infrav1.InstanceStateRunning
-	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-	// 			_, _ = reconciler.reconcileDelete(ms, cs)
-	// 		})
-
-	// 		It("should delete the secret if the AWSMachine is in a failure condition", func() {
-	// 			ms.AWSMachinePool.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
-	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-	// 			_, _ = reconciler.reconcileDelete(ms, cs)
-	// 		})
-	// 	})
-
-	// 	When("there's only a secret ARN and no node ref", func() {
-	// 		BeforeEach(func() {
-	// 			instance = &infrav1.Instance{
-	// 				ID: "myMachine",
-	// 			}
-	// 			ms.AWSMachinePool.Spec.CloudInit = infrav1.CloudInit{
-	// 				SecretPrefix: "secret",
-	// 				SecretCount:  5,
-	// 			}
-	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(instance, nil).AnyTimes()
-	// 		})
-
-	// 		It("should not delete the secret if the instance is running", func() {
-	// 			instance.State = infrav1.InstanceStateRunning
-	// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).
-	// 				Return(map[string][]string{"eid": {}}, nil).Times(1)
-	// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-	// 			secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).MaxTimes(0)
-	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-	// 		})
-
-	// 		It("should delete the secret if the instance is terminated", func() {
-	// 			instance.State = infrav1.InstanceStateTerminated
-	// 			secretSvc.EXPECT().Delete(gomock.Any()).Return(nil).Times(1)
-	// 			_, _ = reconciler.reconcileNormal(context.Background(), ms, cs)
-	// 		})
-
-	// 		It("should delete the secret if the AWSMachine is deleted", func() {
-	// 			instance.State = infrav1.InstanceStateRunning
-	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-	// 			_, _ = reconciler.reconcileDelete(ms, cs)
-	// 		})
-
-	// 		It("should delete the secret if the AWSMachine is in a failure condition", func() {
-	// 			ms.AWSMachinePool.Status.FailureReason = capierrors.MachineStatusErrorPtr(capierrors.UpdateMachineError)
-	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil).AnyTimes()
-	// 			_, _ = reconciler.reconcileDelete(ms, cs)
-	// 		})
-	// 	})
-
-	// 	When("there is an intermittent connection issue and no secret could be stored", func() {
-	// 		BeforeEach(func() {
-	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(nil, nil).AnyTimes()
-	// 		})
-	// 		It("should error if secret could not be created", func() {
-	// 			_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
-	// 			Expect(err).ToNot(BeNil())
-	// 			Expect(err.Error()).To(ContainSubstring("connection error"))
-	// 			Expect(ms.GetSecretPrefix()).To(Equal(""))
-	// 			Expect(ms.GetSecretCount()).To(Equal(int32(0)))
-	// 		})
-
-	// 		It("should update prefix and count on successful creation", func() {
-	// 			instance = &infrav1.Instance{
-	// 				ID: "myMachine",
-	// 			}
-	// 			instance.State = infrav1.InstanceStatePending
-	// 			secretSvc.EXPECT().Create(gomock.Any(), gomock.Any()).Return(secretPrefix, int32(1), nil).Times(1)
-	// 			ec2Svc.EXPECT().CreateInstance(gomock.Any(), gomock.Any()).Return(instance, nil).AnyTimes()
-	// 			ec2Svc.EXPECT().GetInstanceSecurityGroups(gomock.Any()).Return(map[string][]string{"eid": {}}, nil).Times(1)
-	// 			ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{}, nil).Times(1)
-
-	// 			_, err := reconciler.reconcileNormal(context.Background(), ms, cs)
-
-	// 			Expect(err).To(BeNil())
-	// 			Expect(ms.GetSecretPrefix()).To(Equal(secretPrefix))
-	// 			Expect(ms.GetSecretCount()).To(Equal(int32(1)))
-	// 		})
-	// 	})
-	// })
 
 	Context("deleting an AWSMachinePool", func() {
 		BeforeEach(func() {
@@ -564,126 +282,23 @@ var _ = Describe("AWSMachinePoolReconciler", func() {
 			Expect(errors.Cause(err)).To(MatchError(expectedErr))
 		})
 
-		It("should log and remove finalizer when no machine exists", func() {
-			expectedErr := errors.New("no connection available ")
+		It("should log and remove finalizer when no machinepool exists", func() {
 			asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, nil)
-			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, expectedErr).AnyTimes()
+			ec2Svc.EXPECT().GetLaunchTemplate(gomock.Any()).Return(nil, nil).AnyTimes()
 
 			buf := new(bytes.Buffer)
 			klog.SetOutput(buf)
 
 			_, err := reconciler.reconcileDelete(ms, cs)
 			Expect(err).To(BeNil())
-			Expect(buf.String()).To(ContainSubstring("Unable to locate ASG by name"))
+			Expect(buf.String()).To(ContainSubstring("Unable to locate ASG"))
 			Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
 			Eventually(recorder.Events).Should(Receive(ContainSubstring("NoASGFound")))
 		})
-
-		// TODO: remove? Irrelevant?
-		// It("should ignore instances in shutting down state", func() {
-		// 	ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{
-		// 		State: infrav1.InstanceStateShuttingDown,
-		// 	}, nil)
-		// 	asgSvc.EXPECT().GetASGByName(gomock.Any()).Return(nil, nil)
-
-		// 	buf := new(bytes.Buffer)
-		// 	klog.SetOutput(buf)
-
-		// 	_, err := reconciler.reconcileDelete(ms, cs)
-		// 	Expect(err).To(BeNil())
-		// 	Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
-		// 	Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
-		// })
-
-		// It("should ignore instances in terminated down state", func() {
-		// 	ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{
-		// 		State: infrav1.InstanceStateTerminated,
-		// 	}, nil)
-
-		// 	buf := new(bytes.Buffer)
-		// 	klog.SetOutput(buf)
-
-		// 	_, err := reconciler.reconcileDelete(ms, cs)
-		// 	Expect(err).To(BeNil())
-		// 	Expect(buf.String()).To(ContainSubstring("EC2 instance is shutting down or already terminated"))
-		// 	Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
-		// })
-
 	})
-
-	//TODO: remove? Irrelevant
-	// 	Context("Instance not shutting down yet", func() {
-	// 		id := "aws:////myid"
-
-	// 		BeforeEach(func() {
-	// 			ec2Svc.EXPECT().GetRunningInstanceByTags(gomock.Any()).Return(&infrav1.Instance{ID: id}, nil)
-	// 		})
-
-	// 		It("should return an error when the instance can't be terminated", func() {
-	// 			expected := errors.New("can't reach AWS to terminate machine")
-	// 			ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(expected)
-
-	// 			buf := new(bytes.Buffer)
-	// 			klog.SetOutput(buf)
-
-	// 			_, err := reconciler.reconcileDelete(ms, cs)
-	// 			Expect(errors.Cause(err)).To(MatchError(expected))
-	// 			Expect(buf.String()).To(ContainSubstring("Terminating EC2 instance"))
-	// 			Eventually(recorder.Events).Should(Receive(ContainSubstring("FailedTerminate")))
-	// 		})
-
-	// 		When("instance can be shut down", func() {
-	// 			BeforeEach(func() {
-	// 				ec2Svc.EXPECT().TerminateInstanceAndWait(gomock.Any()).Return(nil)
-	// 			})
-
-	// 			When("there are network interfaces", func() {
-	// 				BeforeEach(func() {
-	// 					ms.AWSMachinePool.Spec.NetworkInterfaces = []string{
-	// 						"eth0",
-	// 						"eth1",
-	// 					}
-	// 				})
-
-	// 				It("should error when it can't retrieve security groups", func() {
-	// 					expected := errors.New("can't reach AWS to list security groups")
-	// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return(nil, expected)
-
-	// 					_, err := reconciler.reconcileDelete(ms, cs)
-	// 					Expect(errors.Cause(err)).To(MatchError(expected))
-	// 				})
-
-	// 				It("should error when it can't detach a security group from an interface", func() {
-	// 					expected := errors.New("can't reach AWS to detach security group")
-	// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{"sg0", "sg1"}, nil)
-	// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(gomock.Any(), gomock.Any()).Return(expected)
-
-	// 					_, err := reconciler.reconcileDelete(ms, cs)
-	// 					Expect(errors.Cause(err)).To(MatchError(expected))
-	// 				})
-
-	// 				It("should detach all combinations of network interfaces", func() {
-	// 					groups := []string{"sg0", "sg1"}
-	// 					ec2Svc.EXPECT().GetCoreSecurityGroups(gomock.Any()).Return([]string{"sg0", "sg1"}, nil)
-	// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(groups, "eth0").Return(nil)
-	// 					ec2Svc.EXPECT().DetachSecurityGroupsFromNetworkInterface(groups, "eth1").Return(nil)
-
-	// 					_, err := reconciler.reconcileDelete(ms, cs)
-	// 					Expect(err).To(BeNil())
-	// 				})
-	// 			})
-
-	// 			It("should remove security groups", func() {
-	// 				_, err := reconciler.reconcileDelete(ms, cs)
-	// 				Expect(err).To(BeNil())
-	// 				Expect(ms.AWSMachinePool.Finalizers).To(ConsistOf(metav1.FinalizerDeleteDependents))
-	// 			})
-	// })
-	// })
 })
 
-// })
-
+//TODO: This was taken from awsmachine_controller_test, i think it should be moved to elsewhere in both locations like test/helpers
 func PointsTo(s string) gomock.Matcher {
 	return &pointsTo{
 		val: s,

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -28,13 +28,13 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func(done Done) {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-			filepath.Join("..", "config", "crd", "bases"),
+			filepath.Join("..", "config", "crd", "bases", "exp"),
 		},
 	}
 
@@ -76,9 +76,8 @@ var _ = BeforeSuite(func(done Done) {
 
 	Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(infrav1.AddToScheme(scheme.Scheme)).To(Succeed())
-
-	err = expinfrav1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	Expect(expinfrav1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(expclusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// +kubebuilder:scaffold:scheme
 

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -28,13 +28,14 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -65,7 +66,11 @@ var _ = BeforeSuite(func(done Done) {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
+<<<<<<< HEAD
 			filepath.Join("..", "config", "crd", "bases", "exp"),
+=======
+			filepath.Join("..", "config", "crd", "bases"),
+>>>>>>> ced95eb4... wip: base for integration tests
 		},
 	}
 
@@ -76,8 +81,14 @@ var _ = BeforeSuite(func(done Done) {
 
 	Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(infrav1.AddToScheme(scheme.Scheme)).To(Succeed())
+<<<<<<< HEAD
 	Expect(expinfrav1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(expclusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+=======
+
+	err = expinfrav1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+>>>>>>> ced95eb4... wip: base for integration tests
 
 	// +kubebuilder:scaffold:scheme
 

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -28,14 +28,13 @@ import (
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -66,11 +65,7 @@ var _ = BeforeSuite(func(done Done) {
 	By("bootstrapping test environment")
 	testEnv = &envtest.Environment{
 		CRDDirectoryPaths: []string{
-<<<<<<< HEAD
 			filepath.Join("..", "config", "crd", "bases", "exp"),
-=======
-			filepath.Join("..", "config", "crd", "bases"),
->>>>>>> ced95eb4... wip: base for integration tests
 		},
 	}
 
@@ -81,14 +76,8 @@ var _ = BeforeSuite(func(done Done) {
 
 	Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(infrav1.AddToScheme(scheme.Scheme)).To(Succeed())
-<<<<<<< HEAD
 	Expect(expinfrav1.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(expclusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
-=======
-
-	err = expinfrav1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
->>>>>>> ced95eb4... wip: base for integration tests
 
 	// +kubebuilder:scaffold:scheme
 

--- a/exp/controllers/suite_test.go
+++ b/exp/controllers/suite_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2019 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/klog"
+	"k8s.io/klog/klogr"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	// +kubebuilder:scaffold:imports
+)
+
+// These tests use Ginkgo (BDD-style Go testing framework). Refer to
+// http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+)
+
+func init() {
+	klog.InitFlags(nil)
+	klog.SetOutput(GinkgoWriter)
+	logf.SetLogger(klogr.New())
+}
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+
+	RunSpecsWithDefaultAndCustomReporters(t,
+		"Controller Suite",
+		[]Reporter{printer.NewlineReporter{}})
+}
+
+var _ = BeforeSuite(func(done Done) {
+	By("bootstrapping test environment")
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "config", "crd", "bases"),
+		},
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(cfg).ToNot(BeNil())
+
+	Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(infrav1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	err = expinfrav1.AddToScheme(scheme.Scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	// +kubebuilder:scaffold:scheme
+
+	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+	Expect(err).ToNot(HaveOccurred())
+	Expect(k8sClient).ToNot(BeNil())
+
+	close(done)
+}, 60)
+
+var _ = AfterSuite(func() {
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).ToNot(HaveOccurred())
+})

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -24,9 +24,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/klogr"
+	"k8s.io/utils/pointer"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/exp/api/v1alpha3"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1alpha3"
+	capierrors "sigs.k8s.io/cluster-api/errors"
 	expclusterv1 "sigs.k8s.io/cluster-api/exp/api/v1alpha3"
 	"sigs.k8s.io/cluster-api/util/patch"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -171,4 +173,14 @@ func (m *MachinePoolScope) SetAnnotation(key, value string) {
 		m.AWSMachinePool.Annotations = map[string]string{}
 	}
 	m.AWSMachinePool.Annotations[key] = value
+}
+
+// SetFailureMessage sets the AWSMachine status failure message.
+func (m *MachinePoolScope) SetFailureMessage(v error) {
+	m.AWSMachinePool.Status.FailureMessage = pointer.StringPtr(v.Error())
+}
+
+// SetFailureReason sets the AWSMachine status failure reason.
+func (m *MachinePoolScope) SetFailureReason(v capierrors.MachineStatusError) {
+	m.AWSMachinePool.Status.FailureReason = &v
 }

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -184,3 +184,8 @@ func (m *MachinePoolScope) SetFailureMessage(v error) {
 func (m *MachinePoolScope) SetFailureReason(v capierrors.MachineStatusError) {
 	m.AWSMachinePool.Status.FailureReason = &v
 }
+
+// HasFailed returns true when the AWSMachinePool's Failure reason or Failure message is populated
+func (m *MachinePoolScope) HasFailed() bool {
+	return m.AWSMachinePool.Status.FailureReason != nil || m.AWSMachinePool.Status.FailureMessage != nil
+}


### PR DESCRIPTION
✅ Scope creeped: `// todo: check for failure state, return early`  😂 sorry 😆 
✅ Implemented `SetFailureReason()` and `SetFailureMessage()`
✅ Integration tests that parallel AWSMachine controller's

Future PRs: 
- launch template testing 
- unit tests