### PR TITLE
workaround sshkey regex accept underscores too

### DIFF
--- a/api/v1alpha3/webhooks.go
+++ b/api/v1alpha3/webhooks.go
@@ -38,7 +38,7 @@ func aggregateObjErrors(gk schema.GroupKind, name string, allErrs field.ErrorLis
 func isValidSSHKey(sshKey *string) field.ErrorList {
 	var allErrs field.ErrorList
 	if sshKey != nil {
-		reg, err := regexp.Compile("[^-A-Za-z0-9-]+")
+		reg, err := regexp.Compile("[^-A-Za-z0-9-_]+")
 		if err != nil {
 			return append(allErrs, field.Invalid(field.NewPath("sshKey"), sshKey, "SSHKey contains invalid character"))
 		}


### PR DESCRIPTION
error
`E1021 16:06:47.560458       1 controller.go:257] controller-runtime/controller "msg"="Reconciler error" "error"="failed to sync MachineSet replicas: failed to clone infrastructure configuration for MachineSet \"mn2a-general-nodes-subnet-06f76e12b5fde40e5-6b6859586b\" in namespace \"mn2a\": admission webhook \"validation.awsmachine.infrastructure.cluster.x-k8s.io\" denied the request: AWSMachine.infrastructure.cluster.x-k8s.io \"mn2a-general-nodes-subnet-06f76e12b5fde40e5-pff9r\" is invalid: sshKey: Invalid value: \"confab_development\": SSHKey contains invalid character" "controller"="machineset" "name"="mn2a-general-nodes-subnet-06f76e12b5fde40e5-6b6859586b" "namespace"="mn2a"`