### PR TITLE
✨ Set MachinePool replicas to ASG DesiredCapacity

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -70,6 +70,23 @@ rules:
   - exp.cluster.x-k8s.io
   resources:
   - machinepools
+  verbs:
+  - get
+  - list
+  - patch
+  - watch
+- apiGroups:
+  - exp.cluster.x-k8s.io
+  resources:
+  - machinepools
+  - machinepools/status
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - exp.cluster.x-k8s.io
+  resources:
   - machinepools/status
   verbs:
   - get

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -251,7 +251,7 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 	}
 
 	// Set MachinePool replicas to ASG DesiredCapacity
-	if machinePoolScope.MachinePool.Spec.Replicas != asg.DesiredCapacity {
+	if *machinePoolScope.MachinePool.Spec.Replicas != *asg.DesiredCapacity {
 		machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity", "Replicas", machinePoolScope.MachinePool.Spec.Replicas, "DesiredCapacity", asg.DesiredCapacity)
 		machinePoolScope.MachinePool.Spec.Replicas = asg.DesiredCapacity
 		machinePoolScope.PatchObject(machinePoolScope.MachinePool)

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -251,20 +251,6 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 	}
 
 	if machinePoolScope.MachinePool.Spec.ExternallyManagedReplicaCount {
-		// Set AWSMachinePool minSize to the ASG value
-		if machinePoolScope.AWSMachinePool.Spec.MinSize != asg.MinSize {
-			machinePoolScope.Info("Setting AWSMachinePool minSize to the ASG value",
-				"local", machinePoolScope.AWSMachinePool.Spec.MinSize,
-				"external", asg.MinSize)
-			machinePoolScope.AWSMachinePool.Spec.MinSize = asg.MinSize
-		}
-		// Set AWSMachinePool maxSize to the ASG value
-		if machinePoolScope.AWSMachinePool.Spec.MaxSize != asg.MaxSize {
-			machinePoolScope.Info("Setting AWSMachinePool maxSize to the ASG value",
-				"local", machinePoolScope.AWSMachinePool.Spec.MaxSize,
-				"external", asg.MaxSize)
-			machinePoolScope.AWSMachinePool.Spec.MaxSize = asg.MaxSize
-		}
 		// Set MachinePool replicas to the ASG DesiredCapacity
 		if *machinePoolScope.MachinePool.Spec.Replicas != *asg.DesiredCapacity {
 			machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity",
@@ -479,12 +465,9 @@ func (r *AWSMachinePoolReconciler) reconcileTags(machinePoolScope *scope.Machine
 
 // asgNeedsUpdates compares incoming AWSMachinePool and compares against existing ASG
 func asgNeedsUpdates(machinePoolScope *scope.MachinePoolScope, existingASG *infrav1exp.AutoScalingGroup) bool {
-	if machinePoolScope.MachinePool.Spec.ExternallyManagedReplicaCount {
-		return false
-	}
-
 	if machinePoolScope.MachinePool.Spec.Replicas != nil &&
-		machinePoolScope.MachinePool.Spec.Replicas != existingASG.DesiredCapacity {
+		machinePoolScope.MachinePool.Spec.Replicas != existingASG.DesiredCapacity &&
+		!machinePoolScope.MachinePool.Spec.ExternallyManagedReplicaCount {
 		return true
 	}
 

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -205,7 +205,7 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 	controllerutil.AddFinalizer(machinePoolScope.AWSMachinePool, infrav1exp.MachinePoolFinalizer)
 
 	// Register finalizer immediately to avoid orphaning AWS resources
-	if err := machinePoolScope.PatchObject(); err != nil {
+	if err := machinePoolScope.PatchObject(machinePoolScope.AWSMachinePool); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -254,6 +254,7 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 	if machinePoolScope.MachinePool.Spec.Replicas != asg.DesiredCapacity {
 		machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity", "Replicas", machinePoolScope.MachinePool.Spec.Replicas, "DesiredCapacity", asg.DesiredCapacity)
 		machinePoolScope.MachinePool.Spec.Replicas = asg.DesiredCapacity
+		machinePoolScope.PatchObject(machinePoolScope.MachinePool)
 	}
 
 	if err := r.updatePool(machinePoolScope, clusterScope, asg); err != nil {
@@ -411,7 +412,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 
 		machinePoolScope.AWSMachinePool.Status.LaunchTemplateID = launchTemplateID
 
-		return machinePoolScope.PatchObject()
+		return machinePoolScope.PatchObject(machinePoolScope.AWSMachinePool)
 	}
 
 	annotation, err := r.machinePoolAnnotationJSON(machinePoolScope.AWSMachinePool, TagsLastAppliedAnnotation)

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -205,7 +205,7 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 	controllerutil.AddFinalizer(machinePoolScope.AWSMachinePool, infrav1exp.MachinePoolFinalizer)
 
 	// Register finalizer immediately to avoid orphaning AWS resources
-	if err := machinePoolScope.PatchObject(machinePoolScope.AWSMachinePool); err != nil {
+	if err := machinePoolScope.PatchObject(); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -254,7 +254,7 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 	if *machinePoolScope.MachinePool.Spec.Replicas != *asg.DesiredCapacity {
 		machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity", "Replicas", machinePoolScope.MachinePool.Spec.Replicas, "DesiredCapacity", asg.DesiredCapacity)
 		machinePoolScope.MachinePool.Spec.Replicas = asg.DesiredCapacity
-		machinePoolScope.PatchObject(machinePoolScope.MachinePool)
+		machinePoolScope.PatchMachinePool = true
 	}
 
 	if err := r.updatePool(machinePoolScope, clusterScope, asg); err != nil {
@@ -412,7 +412,7 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 
 		machinePoolScope.AWSMachinePool.Status.LaunchTemplateID = launchTemplateID
 
-		return machinePoolScope.PatchObject(machinePoolScope.AWSMachinePool)
+		return machinePoolScope.PatchObject()
 	}
 
 	annotation, err := r.machinePoolAnnotationJSON(machinePoolScope.AWSMachinePool, TagsLastAppliedAnnotation)

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -251,10 +251,14 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 	}
 
 	// Set MachinePool replicas to ASG DesiredCapacity
-	if *machinePoolScope.MachinePool.Spec.Replicas != *asg.DesiredCapacity {
-		machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity", "Replicas", machinePoolScope.MachinePool.Spec.Replicas, "DesiredCapacity", asg.DesiredCapacity)
-		machinePoolScope.MachinePool.Spec.Replicas = asg.DesiredCapacity
-		machinePoolScope.PatchMachinePool = true
+	if machinePoolScope.MachinePool.Spec.Strategy.Type == "externallyManaged" {
+		if *machinePoolScope.MachinePool.Spec.Replicas != *asg.DesiredCapacity {
+			machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity", "Replicas", machinePoolScope.MachinePool.Spec.Replicas, "DesiredCapacity", asg.DesiredCapacity)
+			machinePoolScope.MachinePool.Spec.Replicas = asg.DesiredCapacity
+			if err := machinePoolScope.PatchHelper.Patch(context.TODO(), machinePoolScope.MachinePool); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
 	}
 
 	if err := r.updatePool(machinePoolScope, clusterScope, asg); err != nil {

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -251,9 +251,11 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 	}
 
 	// Set MachinePool replicas to ASG DesiredCapacity
-	if machinePoolScope.MachinePool.Spec.Strategy.Type == "externallyManaged" {
+	if machinePoolScope.MachinePool.Spec.ExternallyManagedReplicaCount {
 		if *machinePoolScope.MachinePool.Spec.Replicas != *asg.DesiredCapacity {
-			machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity", "Replicas", machinePoolScope.MachinePool.Spec.Replicas, "DesiredCapacity", asg.DesiredCapacity)
+			machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity",
+				"Replicas", machinePoolScope.MachinePool.Spec.Replicas,
+				"DesiredCapacity", asg.DesiredCapacity)
 			machinePoolScope.MachinePool.Spec.Replicas = asg.DesiredCapacity
 			if err := machinePoolScope.PatchHelper.Patch(context.TODO(), machinePoolScope.MachinePool); err != nil {
 				return ctrl.Result{}, err

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -465,7 +465,9 @@ func (r *AWSMachinePoolReconciler) reconcileTags(machinePoolScope *scope.Machine
 
 // asgNeedsUpdates compares incoming AWSMachinePool and compares against existing ASG
 func asgNeedsUpdates(machinePoolScope *scope.MachinePoolScope, existingASG *infrav1exp.AutoScalingGroup) bool {
-	if machinePoolScope.MachinePool.Spec.Replicas != nil && *machinePoolScope.MachinePool.Spec.Replicas != 1 && machinePoolScope.MachinePool.Spec.Replicas != existingASG.DesiredCapacity {
+	if machinePoolScope.MachinePool.Spec.Replicas != nil &&
+		!machinePoolScope.MachinePool.Spec.ExternallyManagedReplicaCount &&
+		machinePoolScope.MachinePool.Spec.Replicas != existingASG.DesiredCapacity {
 		return true
 	}
 

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -250,12 +250,26 @@ func (r *AWSMachinePoolReconciler) reconcileNormal(_ context.Context, machinePoo
 		return ctrl.Result{}, nil
 	}
 
-	// Set MachinePool replicas to ASG DesiredCapacity
 	if machinePoolScope.MachinePool.Spec.ExternallyManagedReplicaCount {
+		// Set AWSMachinePool minSize to the ASG value
+		if machinePoolScope.AWSMachinePool.Spec.MinSize != asg.MinSize {
+			machinePoolScope.Info("Setting AWSMachinePool minSize to the ASG value",
+				"local", machinePoolScope.AWSMachinePool.Spec.MinSize,
+				"external", asg.MinSize)
+			machinePoolScope.AWSMachinePool.Spec.MinSize = asg.MinSize
+		}
+		// Set AWSMachinePool maxSize to the ASG value
+		if machinePoolScope.AWSMachinePool.Spec.MaxSize != asg.MaxSize {
+			machinePoolScope.Info("Setting AWSMachinePool maxSize to the ASG value",
+				"local", machinePoolScope.AWSMachinePool.Spec.MaxSize,
+				"external", asg.MaxSize)
+			machinePoolScope.AWSMachinePool.Spec.MaxSize = asg.MaxSize
+		}
+		// Set MachinePool replicas to the ASG DesiredCapacity
 		if *machinePoolScope.MachinePool.Spec.Replicas != *asg.DesiredCapacity {
 			machinePoolScope.Info("Setting MachinePool replicas to ASG DesiredCapacity",
-				"Replicas", machinePoolScope.MachinePool.Spec.Replicas,
-				"DesiredCapacity", asg.DesiredCapacity)
+				"local", machinePoolScope.MachinePool.Spec.Replicas,
+				"external", asg.DesiredCapacity)
 			machinePoolScope.MachinePool.Spec.Replicas = asg.DesiredCapacity
 			if err := machinePoolScope.PatchHelper.Patch(context.TODO(), machinePoolScope.MachinePool); err != nil {
 				return ctrl.Result{}, err
@@ -465,8 +479,11 @@ func (r *AWSMachinePoolReconciler) reconcileTags(machinePoolScope *scope.Machine
 
 // asgNeedsUpdates compares incoming AWSMachinePool and compares against existing ASG
 func asgNeedsUpdates(machinePoolScope *scope.MachinePoolScope, existingASG *infrav1exp.AutoScalingGroup) bool {
+	if machinePoolScope.MachinePool.Spec.ExternallyManagedReplicaCount {
+		return false
+	}
+
 	if machinePoolScope.MachinePool.Spec.Replicas != nil &&
-		!machinePoolScope.MachinePool.Spec.ExternallyManagedReplicaCount &&
 		machinePoolScope.MachinePool.Spec.Replicas != existingASG.DesiredCapacity {
 		return true
 	}

--- a/pkg/cloud/scope/machinepool.go
+++ b/pkg/cloud/scope/machinepool.go
@@ -22,6 +22,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/klog/klogr"
 	"k8s.io/utils/pointer"
@@ -151,10 +152,10 @@ func (m *MachinePoolScope) AdditionalTags() infrav1.Tags {
 }
 
 // PatchObject persists the machinepool spec and status.
-func (m *MachinePoolScope) PatchObject() error {
+func (m *MachinePoolScope) PatchObject(obj runtime.Object) error {
 	return m.patchHelper.Patch(
 		context.TODO(),
-		m.AWSMachinePool,
+		obj,
 		patch.WithOwnedConditions{Conditions: []clusterv1.ConditionType{
 			expinfrav1.ASGReadyCondition,
 			expinfrav1.LaunchTemplateReadyCondition,
@@ -163,7 +164,7 @@ func (m *MachinePoolScope) PatchObject() error {
 
 // Close the MachinePoolScope by updating the machinepool spec, machine status.
 func (m *MachinePoolScope) Close() error {
-	return m.PatchObject()
+	return m.PatchObject(m.AWSMachinePool)
 }
 
 // SetAnnotation sets a key value annotation on the AWSMachine.

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -275,7 +275,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 		VPCZoneIdentifier:    aws.String(strings.Join(subnetIDs, ", ")),
 	}
 
-	if scope.MachinePool.Spec.Replicas != nil && *scope.MachinePool.Spec.Replicas != 1 {
+	if scope.MachinePool.Spec.Replicas != nil {
 		input.DesiredCapacity = aws.Int64(int64(*scope.MachinePool.Spec.Replicas))
 	}
 


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:
If _MachinePool_'s `spec.externallyManagedReplicaCount` is _true_, then CAPA sets the _MachinePool_ `spec.replicas` to the same value specified in the AWS ASG `DesiredCapacity`.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubernetes-sigs/cluster-api-provider-aws/issues/2022

**Requires**:
https://github.com/newrelic-forks/cluster-api/pull/5
