### PR TITLE
✨  implement capacity rebalance

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -183,6 +183,9 @@ spec:
                     format: int64
                     type: integer
                 type: object
+              capacityRebalance:
+                description: Enable or disable the capacity rebalance autoscaling group feature
+                type: boolean
               defaultCoolDown:
                 description: The amount of time, in seconds, after a scaling activity completes before another scaling activity can start. If no value is supplied by user a default value of 300 seconds is set
                 type: string

--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -72,6 +72,10 @@ type AWSMachinePoolSpec struct {
 	// If no value is supplied by user a default value of 300 seconds is set
 	// +optional
 	DefaultCoolDown metav1.Duration `json:"defaultCoolDown,omitempty"`
+
+	// Enable or disable the capacity rebalance autoscaling group feature
+	// +optional
+	CapacityRebalance bool `json:"capacityRebalance,omitempty"`
 }
 
 // AWSMachinePoolStatus defines the observed state of AWSMachinePool

--- a/exp/api/v1alpha3/types.go
+++ b/exp/api/v1alpha3/types.go
@@ -175,15 +175,16 @@ type Tags map[string]string
 // AutoScalingGroup describes an AWS autoscaling group.
 type AutoScalingGroup struct {
 	// The tags associated with the instance.
-	ID              string          `json:"id,omitempty"`
-	Tags            infrav1.Tags    `json:"tags,omitempty"`
-	Name            string          `json:"name,omitempty"`
-	DesiredCapacity *int32          `json:"desiredCapacity,omitempty"`
-	MaxSize         int32           `json:"maxSize,omitempty"`
-	MinSize         int32           `json:"minSize,omitempty"`
-	PlacementGroup  string          `json:"placementGroup,omitempty"`
-	Subnets         []string        `json:"subnets,omitempty"`
-	DefaultCoolDown metav1.Duration `json:"defaultCoolDown,omitempty"`
+	ID                string          `json:"id,omitempty"`
+	Tags              infrav1.Tags    `json:"tags,omitempty"`
+	Name              string          `json:"name,omitempty"`
+	DesiredCapacity   *int32          `json:"desiredCapacity,omitempty"`
+	MaxSize           int32           `json:"maxSize,omitempty"`
+	MinSize           int32           `json:"minSize,omitempty"`
+	PlacementGroup    string          `json:"placementGroup,omitempty"`
+	Subnets           []string        `json:"subnets,omitempty"`
+	DefaultCoolDown   metav1.Duration `json:"defaultCoolDown,omitempty"`
+	CapacityRebalance bool            `json:"capacityRebalance,omitempty"`
 
 	MixedInstancesPolicy *MixedInstancesPolicy `json:"mixedInstancesPolicy,omitempty"`
 	Status               ASGStatus

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -463,6 +463,10 @@ func asgNeedsUpdates(machinePoolScope *scope.MachinePoolScope, existingASG *infr
 		return true
 	}
 
+	if machinePoolScope.AWSMachinePool.Spec.CapacityRebalance != existingASG.CapacityRebalance {
+		return true
+	}
+
 	if !reflect.DeepEqual(machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy, existingASG.MixedInstancesPolicy) {
 		machinePoolScope.Info("got a mixed diff here", "incoming", machinePoolScope.AWSMachinePool.Spec.MixedInstancesPolicy, "existing", existingASG.MixedInstancesPolicy)
 		return true

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module sigs.k8s.io/cluster-api-provider-aws
 go 1.13
 
 require (
-	github.com/aws/aws-sdk-go v1.35.0
+	github.com/aws/aws-sdk-go v1.36.26
 	github.com/awslabs/goformation/v4 v4.15.0
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/go-logr/logr v0.1.0
@@ -19,7 +19,7 @@ require (
 	github.com/spf13/jwalterweatherman v1.1.0 // indirect
 	github.com/spf13/pflag v1.0.5
 	golang.org/x/crypto v0.0.0-20200930160638-afb6bcd081ae
-	golang.org/x/net v0.0.0-20200930145003-4acb6c075d10
+	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
 	k8s.io/api v0.17.9
 	k8s.io/apimachinery v0.17.9
 	k8s.io/client-go v0.17.9

--- a/go.sum
+++ b/go.sum
@@ -33,8 +33,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aws/aws-sdk-go v1.30.0/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
-github.com/aws/aws-sdk-go v1.35.0 h1:Pxqn1MWNfBCNcX7jrXCCTfsKpg5ms2IMUMmmcGtYJuo=
-github.com/aws/aws-sdk-go v1.35.0/go.mod h1:H7NKnBqNVzoTJpGfLrQkkD+ytBA93eiDYi/+8rV9s48=
+github.com/aws/aws-sdk-go v1.36.26 h1:710u7Q1xpbzpigh/RPPUXwr/5X/VwCxTXSeam8icgos=
+github.com/aws/aws-sdk-go v1.36.26/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/awslabs/goformation/v4 v4.15.0 h1:yZM85dzEKrRIPpMZIdsUV+EWbvhWsfoqC81Fv/aFPck=
 github.com/awslabs/goformation/v4 v4.15.0/go.mod h1:GcJULxCJfloT+3pbqCluXftdEK2AD/UqpS3hkaaBntg=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -99,7 +99,6 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/evanphx/json-patch v4.2.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
-github.com/evanphx/json-patch v4.5.0+incompatible h1:ouOWdg56aJriqS0huScTkVXPC5IcNrDCXZ6OoTAWu7M=
 github.com/evanphx/json-patch v4.5.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/evanphx/json-patch v4.9.0+incompatible h1:kLcOMZeuLAJvL2BPWLMIj5oaZQobrkAqrL+WFZwQses=
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
@@ -177,7 +176,6 @@ github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef h1:veQD95Isof8w9/WXiA+pa3tz3fJXkt5B7QaRBrM62gk=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -215,7 +213,6 @@ github.com/google/gofuzz v0.0.0-20161122191042-44d81051d367/go.mod h1:HP5RmnzzSN
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f h1:5CjVwnuUcp5adK4gmY6i72gpVFVnZDP2h5TmPScB6u4=
 github.com/google/goterm v0.0.0-20190703233501-fc88cf888a3f/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
 github.com/google/goterm v0.0.0-20200907032337-555d40f16ae2 h1:CVuJwN34x4xM2aT4sIKhmeib40NeBPhRihNjQmpJsA4=
 github.com/google/goterm v0.0.0-20200907032337-555d40f16ae2/go.mod h1:nOFQdrUlIlx6M6ODdSpBj1NVA+VgLC6kmw60mkw34H4=
@@ -228,7 +225,6 @@ github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+
 github.com/googleapis/gnostic v0.0.0-20170729233727-0c5108395e2d/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.3.1 h1:WeAefnSUHlBb0iJKwxFDZdbfGwkd7xRNuV+IpXMJhYk=
 github.com/googleapis/gnostic v0.3.1/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
-github.com/gophercloud/gophercloud v0.1.0 h1:P/nh25+rzXouhytV2pUHBb65fnds26Ghl8/391+sT5o=
 github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEoIEcSTewFxm1c5g8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
@@ -256,7 +252,6 @@ github.com/imdario/mergo v0.3.9/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
-github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
 github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
@@ -344,7 +339,6 @@ github.com/onsi/gomega v1.2.0/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5
 github.com/onsi/gomega v1.5.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.0/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
-github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2 h1:aY/nuoWlKJud2J6U0E3NWsjlg+0GtwXxgEqthRdzlcs=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
@@ -368,7 +362,6 @@ github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4
 github.com/prometheus/client_golang v0.9.3/go.mod h1:/TN21ttK/J9q6uSwhBd54HahCDft0ttaMvbicHlPoso=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQP1xR9D75/vuwEF3g=
-github.com/prometheus/client_golang v1.5.1 h1:bdHYieyGlH+6OLEk2YQha8THib30KP0/yD0YH9m6xcA=
 github.com/prometheus/client_golang v1.5.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1 h1:NTGy1Ja9pByO+xAeH/qiWnLrKtr3hJPNjaVUwnjpdpA=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
@@ -382,7 +375,6 @@ github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7q
 github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.6.0/go.mod h1:eBmuwkDJBwy6iBfxCBob6t6dR6ENT/y+J+Zk0j9GMYc=
-github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/common v0.10.0 h1:RyRA7RzGXQZiW+tGMr7sxa85G1z0yOpM1qq5c8lNawc=
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
@@ -392,7 +384,6 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.3/go.mod h1:4A/X28fw3Fc593LaREMrKMqOKvUAntwMDaekg4FpcdQ=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
-github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/procfs v0.1.3 h1:F0+tqvhOksq22sc6iCHF5WGlWjdwj92p0udFh1VFBS8=
 github.com/prometheus/procfs v0.1.3/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
@@ -406,13 +397,11 @@ github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b h1:jUK33OXuZP/l6b
 github.com/sanathkr/go-yaml v0.0.0-20170819195128-ed9d249f429b/go.mod h1:8458kAagoME2+LN5//WxE71ysZ3B7r22fdgb7qVmXSY=
 github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522 h1:fOCp11H0yuyAt2wqlbJtbyPzSgaxHTv8uN1pMpkG1t8=
 github.com/sanathkr/yaml v0.0.0-20170819201035-0056894fa522/go.mod h1:tQTYKOQgxoH3v6dEmdHiz4JG+nbxWwM5fgPQUpSZqVQ=
-github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
-github.com/sirupsen/logrus v1.4.2 h1:SPIRibHv4MatM3XXNO2BJeFLZwZ2LvZgfQ5+UNI2im4=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
@@ -429,7 +418,6 @@ github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0 h1:6m/oheQuQ13N9ks4hubMG6BnvwOeaJrqSPLahSnczz8=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
-github.com/spf13/jwalterweatherman v1.0.0 h1:XHEdyB+EcvlqZamSM4ZOMGlc93t6AcsBEu9Gc1vn7yk=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
@@ -497,7 +485,6 @@ golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200302210943-78000ba7a073/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
-golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de h1:ikNHVSjEfnvz6sxdSPCaPt572qowuyMDMJLLm3Db3ig=
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200930160638-afb6bcd081ae h1:duLSQW+DZ5MsXKX7kc4rXlq6/mmxz4G6ewJuBPlhRe0=
 golang.org/x/crypto v0.0.0-20200930160638-afb6bcd081ae/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
@@ -537,8 +524,8 @@ golang.org/x/net v0.0.0-20191004110552-13f9640d40b9/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200520004742-59133d7f0dd7/go.mod h1:qpuaurCH72eLCgpAm/N6yyVIVM9cpaDIP3A8BGJEC5A=
-golang.org/x/net v0.0.0-20200930145003-4acb6c075d10 h1:YfxMZzv3PjGonQYNUaeU2+DhAdqOxerQ30JFB6WgAXo=
-golang.org/x/net v0.0.0-20200930145003-4acb6c075d10/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b h1:uwuIcX0g4Yl1NC5XAz37xsr2lTtcqevgzYNVt49waME=
+golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -549,7 +536,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e h1:vcxGaoTs7kV8m5Np9uUNQin4BrLOthgV7252N8V+FwY=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -577,12 +563,11 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200106162015-b016eb3dc98e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd h1:xhmwyvizuTgC2qz7ZlMluP20uW+C3Rm0FD/WLDX8884=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200519105757-fe76b779f299 h1:DYfZAGf2WMFjMxbgTjaC+2HC7NkNAQs+6Q8b9WEB/F4=
 golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1 h1:ogLJMz+qpzav7lGMh10LMvAkM/fAoGlaiiHYiFYdm80=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f h1:+Nyd8tzPX9R7BWHguqsrbFdRx3WQ/1ib8I44HXV5yTA=
+golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -591,7 +576,6 @@ golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
@@ -638,7 +622,6 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
-google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
@@ -717,7 +700,6 @@ k8s.io/kube-openapi v0.0.0-20200410145947-bcb3869e6f29/go.mod h1:F+5wygcW0wmRTnM
 k8s.io/sample-controller v0.16.8/go.mod h1:aXlORS1ekU77qhGybB5t3JORDurzDpWgvMYxmCsiuos=
 k8s.io/utils v0.0.0-20190801114015-581e00157fb1/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
 k8s.io/utils v0.0.0-20191114184206-e782cd3c129f/go.mod h1:sZAwmy6armz5eXlNoLmJcl4F1QuKu7sr+mFQ0byX7Ew=
-k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19 h1:7Nu2dTj82c6IaWvL7hImJzcXoTPz1MsSCH7r+0m6rfo=
 k8s.io/utils v0.0.0-20200619165400-6e3d28b6ed19/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 k8s.io/utils v0.0.0-20200912215256-4140de9c8800 h1:9ZNvfPvVIEsp/T1ez4GQuzCcCTEQWhovSofhqR73A6g=
 k8s.io/utils v0.0.0-20200912215256-4140de9c8800/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
@@ -734,7 +716,6 @@ sigs.k8s.io/controller-runtime v0.5.11 h1:U/FjGJ61aR2T2mCrdlBCxEcWgLEwLmK6YZKf0N
 sigs.k8s.io/controller-runtime v0.5.11/go.mod h1:OTqxLuz7gVcrq+BHGUgedRu6b2VIKCEc7Pu4Jbwui0A=
 sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802 h1:L6/8hETA7jvdx3xBcbDifrIN2xaYHE7tA58n+Kdp2Zw=
 sigs.k8s.io/kind v0.7.1-0.20200303021537-981bd80d3802/go.mod h1:HIZ3PWUezpklcjkqpFbnYOqaqsAE1JeCTEwkgvPLXjk=
-sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e h1:4Z09Hglb792X0kfOBBJUPFEyvVfQWrYT/l8h5EKA6JQ=
 sigs.k8s.io/structured-merge-diff v0.0.0-20190525122527-15d366b2352e/go.mod h1:wWxsB5ozmmv/SG7nM11ayaAW51xMvak/t1r0CSlcokI=
 sigs.k8s.io/structured-merge-diff/v2 v2.0.1/go.mod h1:Wb7vfKAodbKgf6tn1Kl0VvGj7mRH6DGaRcixXEJXTsE=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -36,9 +36,10 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscaling.Group) (*expinfrav1.AutoS
 		ID:   aws.StringValue(v.AutoScalingGroupARN),
 		Name: aws.StringValue(v.AutoScalingGroupName),
 		// TODO(rudoi): this is just terrible
-		DesiredCapacity: aws.Int32(int32(aws.Int64Value(v.DesiredCapacity))),
-		MaxSize:         int32(aws.Int64Value(v.MaxSize)),
-		MinSize:         int32(aws.Int64Value(v.MinSize)),
+		DesiredCapacity:   aws.Int32(int32(aws.Int64Value(v.DesiredCapacity))),
+		MaxSize:           int32(aws.Int64Value(v.MaxSize)),
+		MinSize:           int32(aws.Int64Value(v.MinSize)),
+		CapacityRebalance: aws.BoolValue(v.CapacityRebalance),
 		//TODO: determine what additional values go here and what else should be in the struct
 	}
 
@@ -155,6 +156,7 @@ func (s *Service) CreateASG(scope *scope.MachinePoolScope) (*expinfrav1.AutoScal
 		MinSize:              scope.AWSMachinePool.Spec.MinSize,
 		Subnets:              subnetIDs,
 		DefaultCoolDown:      scope.AWSMachinePool.Spec.DefaultCoolDown,
+		CapacityRebalance:    scope.AWSMachinePool.Spec.CapacityRebalance,
 		MixedInstancesPolicy: scope.AWSMachinePool.Spec.MixedInstancesPolicy,
 	}
 
@@ -201,6 +203,7 @@ func (s *Service) runPool(i *expinfrav1.AutoScalingGroup, launchTemplateID strin
 		MinSize:              aws.Int64(int64(i.MinSize)),
 		VPCZoneIdentifier:    aws.String(strings.Join(i.Subnets, ", ")),
 		DefaultCooldown:      aws.Int64(int64(i.DefaultCoolDown.Duration.Seconds())),
+		CapacityRebalance:    aws.Bool(i.CapacityRebalance),
 	}
 
 	if i.DesiredCapacity != nil {
@@ -273,6 +276,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 		MaxSize:              aws.Int64(int64(scope.AWSMachinePool.Spec.MaxSize)),
 		MinSize:              aws.Int64(int64(scope.AWSMachinePool.Spec.MinSize)),
 		VPCZoneIdentifier:    aws.String(strings.Join(subnetIDs, ", ")),
+		CapacityRebalance:    aws.Bool(scope.AWSMachinePool.Spec.CapacityRebalance),
 	}
 
 	if scope.MachinePool.Spec.Replicas != nil && *scope.MachinePool.Spec.Replicas != 1 {

--- a/pkg/cloud/services/ec2/mock_ec2iface/ec2api_mock.go
+++ b/pkg/cloud/services/ec2/mock_ec2iface/ec2api_mock.go
@@ -101,6 +101,56 @@ func (mr *MockEC2APIMockRecorder) AcceptReservedInstancesExchangeQuoteWithContex
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptReservedInstancesExchangeQuoteWithContext", reflect.TypeOf((*MockEC2API)(nil).AcceptReservedInstancesExchangeQuoteWithContext), varargs...)
 }
 
+// AcceptTransitGatewayMulticastDomainAssociations mocks base method
+func (m *MockEC2API) AcceptTransitGatewayMulticastDomainAssociations(arg0 *ec2.AcceptTransitGatewayMulticastDomainAssociationsInput) (*ec2.AcceptTransitGatewayMulticastDomainAssociationsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AcceptTransitGatewayMulticastDomainAssociations", arg0)
+	ret0, _ := ret[0].(*ec2.AcceptTransitGatewayMulticastDomainAssociationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AcceptTransitGatewayMulticastDomainAssociations indicates an expected call of AcceptTransitGatewayMulticastDomainAssociations
+func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayMulticastDomainAssociations(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayMulticastDomainAssociations", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayMulticastDomainAssociations), arg0)
+}
+
+// AcceptTransitGatewayMulticastDomainAssociationsRequest mocks base method
+func (m *MockEC2API) AcceptTransitGatewayMulticastDomainAssociationsRequest(arg0 *ec2.AcceptTransitGatewayMulticastDomainAssociationsInput) (*request.Request, *ec2.AcceptTransitGatewayMulticastDomainAssociationsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AcceptTransitGatewayMulticastDomainAssociationsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AcceptTransitGatewayMulticastDomainAssociationsOutput)
+	return ret0, ret1
+}
+
+// AcceptTransitGatewayMulticastDomainAssociationsRequest indicates an expected call of AcceptTransitGatewayMulticastDomainAssociationsRequest
+func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayMulticastDomainAssociationsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayMulticastDomainAssociationsRequest", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayMulticastDomainAssociationsRequest), arg0)
+}
+
+// AcceptTransitGatewayMulticastDomainAssociationsWithContext mocks base method
+func (m *MockEC2API) AcceptTransitGatewayMulticastDomainAssociationsWithContext(arg0 context.Context, arg1 *ec2.AcceptTransitGatewayMulticastDomainAssociationsInput, arg2 ...request.Option) (*ec2.AcceptTransitGatewayMulticastDomainAssociationsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AcceptTransitGatewayMulticastDomainAssociationsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.AcceptTransitGatewayMulticastDomainAssociationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AcceptTransitGatewayMulticastDomainAssociationsWithContext indicates an expected call of AcceptTransitGatewayMulticastDomainAssociationsWithContext
+func (mr *MockEC2APIMockRecorder) AcceptTransitGatewayMulticastDomainAssociationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AcceptTransitGatewayMulticastDomainAssociationsWithContext", reflect.TypeOf((*MockEC2API)(nil).AcceptTransitGatewayMulticastDomainAssociationsWithContext), varargs...)
+}
+
 // AcceptTransitGatewayPeeringAttachment mocks base method
 func (m *MockEC2API) AcceptTransitGatewayPeeringAttachment(arg0 *ec2.AcceptTransitGatewayPeeringAttachmentInput) (*ec2.AcceptTransitGatewayPeeringAttachmentOutput, error) {
 	m.ctrl.T.Helper()
@@ -749,6 +799,56 @@ func (mr *MockEC2APIMockRecorder) AssociateDhcpOptionsWithContext(arg0, arg1 int
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateDhcpOptionsWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateDhcpOptionsWithContext), varargs...)
+}
+
+// AssociateEnclaveCertificateIamRole mocks base method
+func (m *MockEC2API) AssociateEnclaveCertificateIamRole(arg0 *ec2.AssociateEnclaveCertificateIamRoleInput) (*ec2.AssociateEnclaveCertificateIamRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssociateEnclaveCertificateIamRole", arg0)
+	ret0, _ := ret[0].(*ec2.AssociateEnclaveCertificateIamRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssociateEnclaveCertificateIamRole indicates an expected call of AssociateEnclaveCertificateIamRole
+func (mr *MockEC2APIMockRecorder) AssociateEnclaveCertificateIamRole(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateEnclaveCertificateIamRole", reflect.TypeOf((*MockEC2API)(nil).AssociateEnclaveCertificateIamRole), arg0)
+}
+
+// AssociateEnclaveCertificateIamRoleRequest mocks base method
+func (m *MockEC2API) AssociateEnclaveCertificateIamRoleRequest(arg0 *ec2.AssociateEnclaveCertificateIamRoleInput) (*request.Request, *ec2.AssociateEnclaveCertificateIamRoleOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AssociateEnclaveCertificateIamRoleRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.AssociateEnclaveCertificateIamRoleOutput)
+	return ret0, ret1
+}
+
+// AssociateEnclaveCertificateIamRoleRequest indicates an expected call of AssociateEnclaveCertificateIamRoleRequest
+func (mr *MockEC2APIMockRecorder) AssociateEnclaveCertificateIamRoleRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateEnclaveCertificateIamRoleRequest", reflect.TypeOf((*MockEC2API)(nil).AssociateEnclaveCertificateIamRoleRequest), arg0)
+}
+
+// AssociateEnclaveCertificateIamRoleWithContext mocks base method
+func (m *MockEC2API) AssociateEnclaveCertificateIamRoleWithContext(arg0 context.Context, arg1 *ec2.AssociateEnclaveCertificateIamRoleInput, arg2 ...request.Option) (*ec2.AssociateEnclaveCertificateIamRoleOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "AssociateEnclaveCertificateIamRoleWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.AssociateEnclaveCertificateIamRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AssociateEnclaveCertificateIamRoleWithContext indicates an expected call of AssociateEnclaveCertificateIamRoleWithContext
+func (mr *MockEC2APIMockRecorder) AssociateEnclaveCertificateIamRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssociateEnclaveCertificateIamRoleWithContext", reflect.TypeOf((*MockEC2API)(nil).AssociateEnclaveCertificateIamRoleWithContext), varargs...)
 }
 
 // AssociateIamInstanceProfile mocks base method
@@ -3301,6 +3401,56 @@ func (mr *MockEC2APIMockRecorder) CreateNetworkAclWithContext(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkAclWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkAclWithContext), varargs...)
 }
 
+// CreateNetworkInsightsPath mocks base method
+func (m *MockEC2API) CreateNetworkInsightsPath(arg0 *ec2.CreateNetworkInsightsPathInput) (*ec2.CreateNetworkInsightsPathOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNetworkInsightsPath", arg0)
+	ret0, _ := ret[0].(*ec2.CreateNetworkInsightsPathOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNetworkInsightsPath indicates an expected call of CreateNetworkInsightsPath
+func (mr *MockEC2APIMockRecorder) CreateNetworkInsightsPath(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInsightsPath", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInsightsPath), arg0)
+}
+
+// CreateNetworkInsightsPathRequest mocks base method
+func (m *MockEC2API) CreateNetworkInsightsPathRequest(arg0 *ec2.CreateNetworkInsightsPathInput) (*request.Request, *ec2.CreateNetworkInsightsPathOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateNetworkInsightsPathRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateNetworkInsightsPathOutput)
+	return ret0, ret1
+}
+
+// CreateNetworkInsightsPathRequest indicates an expected call of CreateNetworkInsightsPathRequest
+func (mr *MockEC2APIMockRecorder) CreateNetworkInsightsPathRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInsightsPathRequest", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInsightsPathRequest), arg0)
+}
+
+// CreateNetworkInsightsPathWithContext mocks base method
+func (m *MockEC2API) CreateNetworkInsightsPathWithContext(arg0 context.Context, arg1 *ec2.CreateNetworkInsightsPathInput, arg2 ...request.Option) (*ec2.CreateNetworkInsightsPathOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateNetworkInsightsPathWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateNetworkInsightsPathOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateNetworkInsightsPathWithContext indicates an expected call of CreateNetworkInsightsPathWithContext
+func (mr *MockEC2APIMockRecorder) CreateNetworkInsightsPathWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNetworkInsightsPathWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateNetworkInsightsPathWithContext), varargs...)
+}
+
 // CreateNetworkInterface mocks base method
 func (m *MockEC2API) CreateNetworkInterface(arg0 *ec2.CreateNetworkInterfaceInput) (*ec2.CreateNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()
@@ -4114,6 +4264,106 @@ func (m *MockEC2API) CreateTransitGateway(arg0 *ec2.CreateTransitGatewayInput) (
 func (mr *MockEC2APIMockRecorder) CreateTransitGateway(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGateway", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGateway), arg0)
+}
+
+// CreateTransitGatewayConnect mocks base method
+func (m *MockEC2API) CreateTransitGatewayConnect(arg0 *ec2.CreateTransitGatewayConnectInput) (*ec2.CreateTransitGatewayConnectOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTransitGatewayConnect", arg0)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayConnectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayConnect indicates an expected call of CreateTransitGatewayConnect
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayConnect(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayConnect", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayConnect), arg0)
+}
+
+// CreateTransitGatewayConnectPeer mocks base method
+func (m *MockEC2API) CreateTransitGatewayConnectPeer(arg0 *ec2.CreateTransitGatewayConnectPeerInput) (*ec2.CreateTransitGatewayConnectPeerOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTransitGatewayConnectPeer", arg0)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayConnectPeerOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayConnectPeer indicates an expected call of CreateTransitGatewayConnectPeer
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayConnectPeer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayConnectPeer", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayConnectPeer), arg0)
+}
+
+// CreateTransitGatewayConnectPeerRequest mocks base method
+func (m *MockEC2API) CreateTransitGatewayConnectPeerRequest(arg0 *ec2.CreateTransitGatewayConnectPeerInput) (*request.Request, *ec2.CreateTransitGatewayConnectPeerOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTransitGatewayConnectPeerRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateTransitGatewayConnectPeerOutput)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayConnectPeerRequest indicates an expected call of CreateTransitGatewayConnectPeerRequest
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayConnectPeerRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayConnectPeerRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayConnectPeerRequest), arg0)
+}
+
+// CreateTransitGatewayConnectPeerWithContext mocks base method
+func (m *MockEC2API) CreateTransitGatewayConnectPeerWithContext(arg0 context.Context, arg1 *ec2.CreateTransitGatewayConnectPeerInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayConnectPeerOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateTransitGatewayConnectPeerWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayConnectPeerOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayConnectPeerWithContext indicates an expected call of CreateTransitGatewayConnectPeerWithContext
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayConnectPeerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayConnectPeerWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayConnectPeerWithContext), varargs...)
+}
+
+// CreateTransitGatewayConnectRequest mocks base method
+func (m *MockEC2API) CreateTransitGatewayConnectRequest(arg0 *ec2.CreateTransitGatewayConnectInput) (*request.Request, *ec2.CreateTransitGatewayConnectOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTransitGatewayConnectRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.CreateTransitGatewayConnectOutput)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayConnectRequest indicates an expected call of CreateTransitGatewayConnectRequest
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayConnectRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayConnectRequest", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayConnectRequest), arg0)
+}
+
+// CreateTransitGatewayConnectWithContext mocks base method
+func (m *MockEC2API) CreateTransitGatewayConnectWithContext(arg0 context.Context, arg1 *ec2.CreateTransitGatewayConnectInput, arg2 ...request.Option) (*ec2.CreateTransitGatewayConnectOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateTransitGatewayConnectWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.CreateTransitGatewayConnectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTransitGatewayConnectWithContext indicates an expected call of CreateTransitGatewayConnectWithContext
+func (mr *MockEC2APIMockRecorder) CreateTransitGatewayConnectWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransitGatewayConnectWithContext", reflect.TypeOf((*MockEC2API)(nil).CreateTransitGatewayConnectWithContext), varargs...)
 }
 
 // CreateTransitGatewayMulticastDomain mocks base method
@@ -5851,6 +6101,106 @@ func (mr *MockEC2APIMockRecorder) DeleteNetworkAclWithContext(arg0, arg1 interfa
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkAclWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkAclWithContext), varargs...)
 }
 
+// DeleteNetworkInsightsAnalysis mocks base method
+func (m *MockEC2API) DeleteNetworkInsightsAnalysis(arg0 *ec2.DeleteNetworkInsightsAnalysisInput) (*ec2.DeleteNetworkInsightsAnalysisOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNetworkInsightsAnalysis", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteNetworkInsightsAnalysisOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNetworkInsightsAnalysis indicates an expected call of DeleteNetworkInsightsAnalysis
+func (mr *MockEC2APIMockRecorder) DeleteNetworkInsightsAnalysis(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInsightsAnalysis", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInsightsAnalysis), arg0)
+}
+
+// DeleteNetworkInsightsAnalysisRequest mocks base method
+func (m *MockEC2API) DeleteNetworkInsightsAnalysisRequest(arg0 *ec2.DeleteNetworkInsightsAnalysisInput) (*request.Request, *ec2.DeleteNetworkInsightsAnalysisOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNetworkInsightsAnalysisRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteNetworkInsightsAnalysisOutput)
+	return ret0, ret1
+}
+
+// DeleteNetworkInsightsAnalysisRequest indicates an expected call of DeleteNetworkInsightsAnalysisRequest
+func (mr *MockEC2APIMockRecorder) DeleteNetworkInsightsAnalysisRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInsightsAnalysisRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInsightsAnalysisRequest), arg0)
+}
+
+// DeleteNetworkInsightsAnalysisWithContext mocks base method
+func (m *MockEC2API) DeleteNetworkInsightsAnalysisWithContext(arg0 context.Context, arg1 *ec2.DeleteNetworkInsightsAnalysisInput, arg2 ...request.Option) (*ec2.DeleteNetworkInsightsAnalysisOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteNetworkInsightsAnalysisWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteNetworkInsightsAnalysisOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNetworkInsightsAnalysisWithContext indicates an expected call of DeleteNetworkInsightsAnalysisWithContext
+func (mr *MockEC2APIMockRecorder) DeleteNetworkInsightsAnalysisWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInsightsAnalysisWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInsightsAnalysisWithContext), varargs...)
+}
+
+// DeleteNetworkInsightsPath mocks base method
+func (m *MockEC2API) DeleteNetworkInsightsPath(arg0 *ec2.DeleteNetworkInsightsPathInput) (*ec2.DeleteNetworkInsightsPathOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNetworkInsightsPath", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteNetworkInsightsPathOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNetworkInsightsPath indicates an expected call of DeleteNetworkInsightsPath
+func (mr *MockEC2APIMockRecorder) DeleteNetworkInsightsPath(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInsightsPath", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInsightsPath), arg0)
+}
+
+// DeleteNetworkInsightsPathRequest mocks base method
+func (m *MockEC2API) DeleteNetworkInsightsPathRequest(arg0 *ec2.DeleteNetworkInsightsPathInput) (*request.Request, *ec2.DeleteNetworkInsightsPathOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteNetworkInsightsPathRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteNetworkInsightsPathOutput)
+	return ret0, ret1
+}
+
+// DeleteNetworkInsightsPathRequest indicates an expected call of DeleteNetworkInsightsPathRequest
+func (mr *MockEC2APIMockRecorder) DeleteNetworkInsightsPathRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInsightsPathRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInsightsPathRequest), arg0)
+}
+
+// DeleteNetworkInsightsPathWithContext mocks base method
+func (m *MockEC2API) DeleteNetworkInsightsPathWithContext(arg0 context.Context, arg1 *ec2.DeleteNetworkInsightsPathInput, arg2 ...request.Option) (*ec2.DeleteNetworkInsightsPathOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteNetworkInsightsPathWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteNetworkInsightsPathOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteNetworkInsightsPathWithContext indicates an expected call of DeleteNetworkInsightsPathWithContext
+func (mr *MockEC2APIMockRecorder) DeleteNetworkInsightsPathWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNetworkInsightsPathWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteNetworkInsightsPathWithContext), varargs...)
+}
+
 // DeleteNetworkInterface mocks base method
 func (m *MockEC2API) DeleteNetworkInterface(arg0 *ec2.DeleteNetworkInterfaceInput) (*ec2.DeleteNetworkInterfaceOutput, error) {
 	m.ctrl.T.Helper()
@@ -6614,6 +6964,106 @@ func (m *MockEC2API) DeleteTransitGateway(arg0 *ec2.DeleteTransitGatewayInput) (
 func (mr *MockEC2APIMockRecorder) DeleteTransitGateway(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGateway", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGateway), arg0)
+}
+
+// DeleteTransitGatewayConnect mocks base method
+func (m *MockEC2API) DeleteTransitGatewayConnect(arg0 *ec2.DeleteTransitGatewayConnectInput) (*ec2.DeleteTransitGatewayConnectOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayConnect", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayConnectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayConnect indicates an expected call of DeleteTransitGatewayConnect
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayConnect(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayConnect", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayConnect), arg0)
+}
+
+// DeleteTransitGatewayConnectPeer mocks base method
+func (m *MockEC2API) DeleteTransitGatewayConnectPeer(arg0 *ec2.DeleteTransitGatewayConnectPeerInput) (*ec2.DeleteTransitGatewayConnectPeerOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayConnectPeer", arg0)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayConnectPeerOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayConnectPeer indicates an expected call of DeleteTransitGatewayConnectPeer
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayConnectPeer(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayConnectPeer", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayConnectPeer), arg0)
+}
+
+// DeleteTransitGatewayConnectPeerRequest mocks base method
+func (m *MockEC2API) DeleteTransitGatewayConnectPeerRequest(arg0 *ec2.DeleteTransitGatewayConnectPeerInput) (*request.Request, *ec2.DeleteTransitGatewayConnectPeerOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayConnectPeerRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayConnectPeerOutput)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayConnectPeerRequest indicates an expected call of DeleteTransitGatewayConnectPeerRequest
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayConnectPeerRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayConnectPeerRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayConnectPeerRequest), arg0)
+}
+
+// DeleteTransitGatewayConnectPeerWithContext mocks base method
+func (m *MockEC2API) DeleteTransitGatewayConnectPeerWithContext(arg0 context.Context, arg1 *ec2.DeleteTransitGatewayConnectPeerInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayConnectPeerOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayConnectPeerWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayConnectPeerOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayConnectPeerWithContext indicates an expected call of DeleteTransitGatewayConnectPeerWithContext
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayConnectPeerWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayConnectPeerWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayConnectPeerWithContext), varargs...)
+}
+
+// DeleteTransitGatewayConnectRequest mocks base method
+func (m *MockEC2API) DeleteTransitGatewayConnectRequest(arg0 *ec2.DeleteTransitGatewayConnectInput) (*request.Request, *ec2.DeleteTransitGatewayConnectOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayConnectRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DeleteTransitGatewayConnectOutput)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayConnectRequest indicates an expected call of DeleteTransitGatewayConnectRequest
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayConnectRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayConnectRequest", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayConnectRequest), arg0)
+}
+
+// DeleteTransitGatewayConnectWithContext mocks base method
+func (m *MockEC2API) DeleteTransitGatewayConnectWithContext(arg0 context.Context, arg1 *ec2.DeleteTransitGatewayConnectInput, arg2 ...request.Option) (*ec2.DeleteTransitGatewayConnectOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteTransitGatewayConnectWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DeleteTransitGatewayConnectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteTransitGatewayConnectWithContext indicates an expected call of DeleteTransitGatewayConnectWithContext
+func (mr *MockEC2APIMockRecorder) DeleteTransitGatewayConnectWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransitGatewayConnectWithContext", reflect.TypeOf((*MockEC2API)(nil).DeleteTransitGatewayConnectWithContext), varargs...)
 }
 
 // DeleteTransitGatewayMulticastDomain mocks base method
@@ -12087,6 +12537,172 @@ func (mr *MockEC2APIMockRecorder) DescribeNetworkAclsWithContext(arg0, arg1 inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkAclsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkAclsWithContext), varargs...)
 }
 
+// DescribeNetworkInsightsAnalyses mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsAnalyses(arg0 *ec2.DescribeNetworkInsightsAnalysesInput) (*ec2.DescribeNetworkInsightsAnalysesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsAnalyses", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeNetworkInsightsAnalysesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeNetworkInsightsAnalyses indicates an expected call of DescribeNetworkInsightsAnalyses
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsAnalyses(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsAnalyses", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsAnalyses), arg0)
+}
+
+// DescribeNetworkInsightsAnalysesPages mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsAnalysesPages(arg0 *ec2.DescribeNetworkInsightsAnalysesInput, arg1 func(*ec2.DescribeNetworkInsightsAnalysesOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsAnalysesPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeNetworkInsightsAnalysesPages indicates an expected call of DescribeNetworkInsightsAnalysesPages
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsAnalysesPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsAnalysesPages", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsAnalysesPages), arg0, arg1)
+}
+
+// DescribeNetworkInsightsAnalysesPagesWithContext mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsAnalysesPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInsightsAnalysesInput, arg2 func(*ec2.DescribeNetworkInsightsAnalysesOutput, bool) bool, arg3 ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsAnalysesPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeNetworkInsightsAnalysesPagesWithContext indicates an expected call of DescribeNetworkInsightsAnalysesPagesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsAnalysesPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsAnalysesPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsAnalysesPagesWithContext), varargs...)
+}
+
+// DescribeNetworkInsightsAnalysesRequest mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsAnalysesRequest(arg0 *ec2.DescribeNetworkInsightsAnalysesInput) (*request.Request, *ec2.DescribeNetworkInsightsAnalysesOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsAnalysesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeNetworkInsightsAnalysesOutput)
+	return ret0, ret1
+}
+
+// DescribeNetworkInsightsAnalysesRequest indicates an expected call of DescribeNetworkInsightsAnalysesRequest
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsAnalysesRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsAnalysesRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsAnalysesRequest), arg0)
+}
+
+// DescribeNetworkInsightsAnalysesWithContext mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsAnalysesWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInsightsAnalysesInput, arg2 ...request.Option) (*ec2.DescribeNetworkInsightsAnalysesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsAnalysesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeNetworkInsightsAnalysesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeNetworkInsightsAnalysesWithContext indicates an expected call of DescribeNetworkInsightsAnalysesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsAnalysesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsAnalysesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsAnalysesWithContext), varargs...)
+}
+
+// DescribeNetworkInsightsPaths mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsPaths(arg0 *ec2.DescribeNetworkInsightsPathsInput) (*ec2.DescribeNetworkInsightsPathsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsPaths", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeNetworkInsightsPathsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeNetworkInsightsPaths indicates an expected call of DescribeNetworkInsightsPaths
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsPaths(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsPaths", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsPaths), arg0)
+}
+
+// DescribeNetworkInsightsPathsPages mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsPathsPages(arg0 *ec2.DescribeNetworkInsightsPathsInput, arg1 func(*ec2.DescribeNetworkInsightsPathsOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsPathsPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeNetworkInsightsPathsPages indicates an expected call of DescribeNetworkInsightsPathsPages
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsPathsPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsPathsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsPathsPages), arg0, arg1)
+}
+
+// DescribeNetworkInsightsPathsPagesWithContext mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsPathsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInsightsPathsInput, arg2 func(*ec2.DescribeNetworkInsightsPathsOutput, bool) bool, arg3 ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsPathsPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeNetworkInsightsPathsPagesWithContext indicates an expected call of DescribeNetworkInsightsPathsPagesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsPathsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsPathsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsPathsPagesWithContext), varargs...)
+}
+
+// DescribeNetworkInsightsPathsRequest mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsPathsRequest(arg0 *ec2.DescribeNetworkInsightsPathsInput) (*request.Request, *ec2.DescribeNetworkInsightsPathsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsPathsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeNetworkInsightsPathsOutput)
+	return ret0, ret1
+}
+
+// DescribeNetworkInsightsPathsRequest indicates an expected call of DescribeNetworkInsightsPathsRequest
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsPathsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsPathsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsPathsRequest), arg0)
+}
+
+// DescribeNetworkInsightsPathsWithContext mocks base method
+func (m *MockEC2API) DescribeNetworkInsightsPathsWithContext(arg0 context.Context, arg1 *ec2.DescribeNetworkInsightsPathsInput, arg2 ...request.Option) (*ec2.DescribeNetworkInsightsPathsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeNetworkInsightsPathsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeNetworkInsightsPathsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeNetworkInsightsPathsWithContext indicates an expected call of DescribeNetworkInsightsPathsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeNetworkInsightsPathsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeNetworkInsightsPathsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeNetworkInsightsPathsWithContext), varargs...)
+}
+
 // DescribeNetworkInterfaceAttribute mocks base method
 func (m *MockEC2API) DescribeNetworkInterfaceAttribute(arg0 *ec2.DescribeNetworkInterfaceAttributeInput) (*ec2.DescribeNetworkInterfaceAttributeOutput, error) {
 	m.ctrl.T.Helper()
@@ -14413,6 +15029,172 @@ func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayAttachmentsWithContext(a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayAttachmentsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayAttachmentsWithContext), varargs...)
 }
 
+// DescribeTransitGatewayConnectPeers mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectPeers(arg0 *ec2.DescribeTransitGatewayConnectPeersInput) (*ec2.DescribeTransitGatewayConnectPeersOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectPeers", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayConnectPeersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayConnectPeers indicates an expected call of DescribeTransitGatewayConnectPeers
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectPeers(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectPeers", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectPeers), arg0)
+}
+
+// DescribeTransitGatewayConnectPeersPages mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectPeersPages(arg0 *ec2.DescribeTransitGatewayConnectPeersInput, arg1 func(*ec2.DescribeTransitGatewayConnectPeersOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectPeersPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeTransitGatewayConnectPeersPages indicates an expected call of DescribeTransitGatewayConnectPeersPages
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectPeersPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectPeersPages", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectPeersPages), arg0, arg1)
+}
+
+// DescribeTransitGatewayConnectPeersPagesWithContext mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectPeersPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeTransitGatewayConnectPeersInput, arg2 func(*ec2.DescribeTransitGatewayConnectPeersOutput, bool) bool, arg3 ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectPeersPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeTransitGatewayConnectPeersPagesWithContext indicates an expected call of DescribeTransitGatewayConnectPeersPagesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectPeersPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectPeersPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectPeersPagesWithContext), varargs...)
+}
+
+// DescribeTransitGatewayConnectPeersRequest mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectPeersRequest(arg0 *ec2.DescribeTransitGatewayConnectPeersInput) (*request.Request, *ec2.DescribeTransitGatewayConnectPeersOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectPeersRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeTransitGatewayConnectPeersOutput)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayConnectPeersRequest indicates an expected call of DescribeTransitGatewayConnectPeersRequest
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectPeersRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectPeersRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectPeersRequest), arg0)
+}
+
+// DescribeTransitGatewayConnectPeersWithContext mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectPeersWithContext(arg0 context.Context, arg1 *ec2.DescribeTransitGatewayConnectPeersInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewayConnectPeersOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectPeersWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayConnectPeersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayConnectPeersWithContext indicates an expected call of DescribeTransitGatewayConnectPeersWithContext
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectPeersWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectPeersWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectPeersWithContext), varargs...)
+}
+
+// DescribeTransitGatewayConnects mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnects(arg0 *ec2.DescribeTransitGatewayConnectsInput) (*ec2.DescribeTransitGatewayConnectsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnects", arg0)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayConnectsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayConnects indicates an expected call of DescribeTransitGatewayConnects
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnects(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnects", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnects), arg0)
+}
+
+// DescribeTransitGatewayConnectsPages mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectsPages(arg0 *ec2.DescribeTransitGatewayConnectsInput, arg1 func(*ec2.DescribeTransitGatewayConnectsOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectsPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeTransitGatewayConnectsPages indicates an expected call of DescribeTransitGatewayConnectsPages
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectsPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectsPages", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectsPages), arg0, arg1)
+}
+
+// DescribeTransitGatewayConnectsPagesWithContext mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectsPagesWithContext(arg0 context.Context, arg1 *ec2.DescribeTransitGatewayConnectsInput, arg2 func(*ec2.DescribeTransitGatewayConnectsOutput, bool) bool, arg3 ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectsPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeTransitGatewayConnectsPagesWithContext indicates an expected call of DescribeTransitGatewayConnectsPagesWithContext
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectsPagesWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectsPagesWithContext), varargs...)
+}
+
+// DescribeTransitGatewayConnectsRequest mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectsRequest(arg0 *ec2.DescribeTransitGatewayConnectsInput) (*request.Request, *ec2.DescribeTransitGatewayConnectsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DescribeTransitGatewayConnectsOutput)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayConnectsRequest indicates an expected call of DescribeTransitGatewayConnectsRequest
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectsRequest", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectsRequest), arg0)
+}
+
+// DescribeTransitGatewayConnectsWithContext mocks base method
+func (m *MockEC2API) DescribeTransitGatewayConnectsWithContext(arg0 context.Context, arg1 *ec2.DescribeTransitGatewayConnectsInput, arg2 ...request.Option) (*ec2.DescribeTransitGatewayConnectsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeTransitGatewayConnectsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DescribeTransitGatewayConnectsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeTransitGatewayConnectsWithContext indicates an expected call of DescribeTransitGatewayConnectsWithContext
+func (mr *MockEC2APIMockRecorder) DescribeTransitGatewayConnectsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeTransitGatewayConnectsWithContext", reflect.TypeOf((*MockEC2API)(nil).DescribeTransitGatewayConnectsWithContext), varargs...)
+}
+
 // DescribeTransitGatewayMulticastDomains mocks base method
 func (m *MockEC2API) DescribeTransitGatewayMulticastDomains(arg0 *ec2.DescribeTransitGatewayMulticastDomainsInput) (*ec2.DescribeTransitGatewayMulticastDomainsOutput, error) {
 	m.ctrl.T.Helper()
@@ -16691,6 +17473,56 @@ func (mr *MockEC2APIMockRecorder) DisassociateClientVpnTargetNetworkWithContext(
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateClientVpnTargetNetworkWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateClientVpnTargetNetworkWithContext), varargs...)
 }
 
+// DisassociateEnclaveCertificateIamRole mocks base method
+func (m *MockEC2API) DisassociateEnclaveCertificateIamRole(arg0 *ec2.DisassociateEnclaveCertificateIamRoleInput) (*ec2.DisassociateEnclaveCertificateIamRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisassociateEnclaveCertificateIamRole", arg0)
+	ret0, _ := ret[0].(*ec2.DisassociateEnclaveCertificateIamRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisassociateEnclaveCertificateIamRole indicates an expected call of DisassociateEnclaveCertificateIamRole
+func (mr *MockEC2APIMockRecorder) DisassociateEnclaveCertificateIamRole(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateEnclaveCertificateIamRole", reflect.TypeOf((*MockEC2API)(nil).DisassociateEnclaveCertificateIamRole), arg0)
+}
+
+// DisassociateEnclaveCertificateIamRoleRequest mocks base method
+func (m *MockEC2API) DisassociateEnclaveCertificateIamRoleRequest(arg0 *ec2.DisassociateEnclaveCertificateIamRoleInput) (*request.Request, *ec2.DisassociateEnclaveCertificateIamRoleOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DisassociateEnclaveCertificateIamRoleRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.DisassociateEnclaveCertificateIamRoleOutput)
+	return ret0, ret1
+}
+
+// DisassociateEnclaveCertificateIamRoleRequest indicates an expected call of DisassociateEnclaveCertificateIamRoleRequest
+func (mr *MockEC2APIMockRecorder) DisassociateEnclaveCertificateIamRoleRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateEnclaveCertificateIamRoleRequest", reflect.TypeOf((*MockEC2API)(nil).DisassociateEnclaveCertificateIamRoleRequest), arg0)
+}
+
+// DisassociateEnclaveCertificateIamRoleWithContext mocks base method
+func (m *MockEC2API) DisassociateEnclaveCertificateIamRoleWithContext(arg0 context.Context, arg1 *ec2.DisassociateEnclaveCertificateIamRoleInput, arg2 ...request.Option) (*ec2.DisassociateEnclaveCertificateIamRoleOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DisassociateEnclaveCertificateIamRoleWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.DisassociateEnclaveCertificateIamRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DisassociateEnclaveCertificateIamRoleWithContext indicates an expected call of DisassociateEnclaveCertificateIamRoleWithContext
+func (mr *MockEC2APIMockRecorder) DisassociateEnclaveCertificateIamRoleWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DisassociateEnclaveCertificateIamRoleWithContext", reflect.TypeOf((*MockEC2API)(nil).DisassociateEnclaveCertificateIamRoleWithContext), varargs...)
+}
+
 // DisassociateIamInstanceProfile mocks base method
 func (m *MockEC2API) DisassociateIamInstanceProfile(arg0 *ec2.DisassociateIamInstanceProfileInput) (*ec2.DisassociateIamInstanceProfileOutput, error) {
 	m.ctrl.T.Helper()
@@ -17539,6 +18371,56 @@ func (mr *MockEC2APIMockRecorder) ExportTransitGatewayRoutesWithContext(arg0, ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ExportTransitGatewayRoutesWithContext", reflect.TypeOf((*MockEC2API)(nil).ExportTransitGatewayRoutesWithContext), varargs...)
+}
+
+// GetAssociatedEnclaveCertificateIamRoles mocks base method
+func (m *MockEC2API) GetAssociatedEnclaveCertificateIamRoles(arg0 *ec2.GetAssociatedEnclaveCertificateIamRolesInput) (*ec2.GetAssociatedEnclaveCertificateIamRolesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAssociatedEnclaveCertificateIamRoles", arg0)
+	ret0, _ := ret[0].(*ec2.GetAssociatedEnclaveCertificateIamRolesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssociatedEnclaveCertificateIamRoles indicates an expected call of GetAssociatedEnclaveCertificateIamRoles
+func (mr *MockEC2APIMockRecorder) GetAssociatedEnclaveCertificateIamRoles(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssociatedEnclaveCertificateIamRoles", reflect.TypeOf((*MockEC2API)(nil).GetAssociatedEnclaveCertificateIamRoles), arg0)
+}
+
+// GetAssociatedEnclaveCertificateIamRolesRequest mocks base method
+func (m *MockEC2API) GetAssociatedEnclaveCertificateIamRolesRequest(arg0 *ec2.GetAssociatedEnclaveCertificateIamRolesInput) (*request.Request, *ec2.GetAssociatedEnclaveCertificateIamRolesOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAssociatedEnclaveCertificateIamRolesRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.GetAssociatedEnclaveCertificateIamRolesOutput)
+	return ret0, ret1
+}
+
+// GetAssociatedEnclaveCertificateIamRolesRequest indicates an expected call of GetAssociatedEnclaveCertificateIamRolesRequest
+func (mr *MockEC2APIMockRecorder) GetAssociatedEnclaveCertificateIamRolesRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssociatedEnclaveCertificateIamRolesRequest", reflect.TypeOf((*MockEC2API)(nil).GetAssociatedEnclaveCertificateIamRolesRequest), arg0)
+}
+
+// GetAssociatedEnclaveCertificateIamRolesWithContext mocks base method
+func (m *MockEC2API) GetAssociatedEnclaveCertificateIamRolesWithContext(arg0 context.Context, arg1 *ec2.GetAssociatedEnclaveCertificateIamRolesInput, arg2 ...request.Option) (*ec2.GetAssociatedEnclaveCertificateIamRolesOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetAssociatedEnclaveCertificateIamRolesWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.GetAssociatedEnclaveCertificateIamRolesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetAssociatedEnclaveCertificateIamRolesWithContext indicates an expected call of GetAssociatedEnclaveCertificateIamRolesWithContext
+func (mr *MockEC2APIMockRecorder) GetAssociatedEnclaveCertificateIamRolesWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssociatedEnclaveCertificateIamRolesWithContext", reflect.TypeOf((*MockEC2API)(nil).GetAssociatedEnclaveCertificateIamRolesWithContext), varargs...)
 }
 
 // GetAssociatedIpv6PoolCidrs mocks base method
@@ -21838,6 +22720,56 @@ func (mr *MockEC2APIMockRecorder) RegisterTransitGatewayMulticastGroupSourcesWit
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterTransitGatewayMulticastGroupSourcesWithContext", reflect.TypeOf((*MockEC2API)(nil).RegisterTransitGatewayMulticastGroupSourcesWithContext), varargs...)
 }
 
+// RejectTransitGatewayMulticastDomainAssociations mocks base method
+func (m *MockEC2API) RejectTransitGatewayMulticastDomainAssociations(arg0 *ec2.RejectTransitGatewayMulticastDomainAssociationsInput) (*ec2.RejectTransitGatewayMulticastDomainAssociationsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RejectTransitGatewayMulticastDomainAssociations", arg0)
+	ret0, _ := ret[0].(*ec2.RejectTransitGatewayMulticastDomainAssociationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RejectTransitGatewayMulticastDomainAssociations indicates an expected call of RejectTransitGatewayMulticastDomainAssociations
+func (mr *MockEC2APIMockRecorder) RejectTransitGatewayMulticastDomainAssociations(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayMulticastDomainAssociations", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayMulticastDomainAssociations), arg0)
+}
+
+// RejectTransitGatewayMulticastDomainAssociationsRequest mocks base method
+func (m *MockEC2API) RejectTransitGatewayMulticastDomainAssociationsRequest(arg0 *ec2.RejectTransitGatewayMulticastDomainAssociationsInput) (*request.Request, *ec2.RejectTransitGatewayMulticastDomainAssociationsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RejectTransitGatewayMulticastDomainAssociationsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.RejectTransitGatewayMulticastDomainAssociationsOutput)
+	return ret0, ret1
+}
+
+// RejectTransitGatewayMulticastDomainAssociationsRequest indicates an expected call of RejectTransitGatewayMulticastDomainAssociationsRequest
+func (mr *MockEC2APIMockRecorder) RejectTransitGatewayMulticastDomainAssociationsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayMulticastDomainAssociationsRequest", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayMulticastDomainAssociationsRequest), arg0)
+}
+
+// RejectTransitGatewayMulticastDomainAssociationsWithContext mocks base method
+func (m *MockEC2API) RejectTransitGatewayMulticastDomainAssociationsWithContext(arg0 context.Context, arg1 *ec2.RejectTransitGatewayMulticastDomainAssociationsInput, arg2 ...request.Option) (*ec2.RejectTransitGatewayMulticastDomainAssociationsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "RejectTransitGatewayMulticastDomainAssociationsWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.RejectTransitGatewayMulticastDomainAssociationsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RejectTransitGatewayMulticastDomainAssociationsWithContext indicates an expected call of RejectTransitGatewayMulticastDomainAssociationsWithContext
+func (mr *MockEC2APIMockRecorder) RejectTransitGatewayMulticastDomainAssociationsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RejectTransitGatewayMulticastDomainAssociationsWithContext", reflect.TypeOf((*MockEC2API)(nil).RejectTransitGatewayMulticastDomainAssociationsWithContext), varargs...)
+}
+
 // RejectTransitGatewayPeeringAttachment mocks base method
 func (m *MockEC2API) RejectTransitGatewayPeeringAttachment(arg0 *ec2.RejectTransitGatewayPeeringAttachmentInput) (*ec2.RejectTransitGatewayPeeringAttachmentOutput, error) {
 	m.ctrl.T.Helper()
@@ -23552,6 +24484,56 @@ func (mr *MockEC2APIMockRecorder) StartInstancesWithContext(arg0, arg1 interface
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartInstancesWithContext", reflect.TypeOf((*MockEC2API)(nil).StartInstancesWithContext), varargs...)
+}
+
+// StartNetworkInsightsAnalysis mocks base method
+func (m *MockEC2API) StartNetworkInsightsAnalysis(arg0 *ec2.StartNetworkInsightsAnalysisInput) (*ec2.StartNetworkInsightsAnalysisOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartNetworkInsightsAnalysis", arg0)
+	ret0, _ := ret[0].(*ec2.StartNetworkInsightsAnalysisOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartNetworkInsightsAnalysis indicates an expected call of StartNetworkInsightsAnalysis
+func (mr *MockEC2APIMockRecorder) StartNetworkInsightsAnalysis(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartNetworkInsightsAnalysis", reflect.TypeOf((*MockEC2API)(nil).StartNetworkInsightsAnalysis), arg0)
+}
+
+// StartNetworkInsightsAnalysisRequest mocks base method
+func (m *MockEC2API) StartNetworkInsightsAnalysisRequest(arg0 *ec2.StartNetworkInsightsAnalysisInput) (*request.Request, *ec2.StartNetworkInsightsAnalysisOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "StartNetworkInsightsAnalysisRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*ec2.StartNetworkInsightsAnalysisOutput)
+	return ret0, ret1
+}
+
+// StartNetworkInsightsAnalysisRequest indicates an expected call of StartNetworkInsightsAnalysisRequest
+func (mr *MockEC2APIMockRecorder) StartNetworkInsightsAnalysisRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartNetworkInsightsAnalysisRequest", reflect.TypeOf((*MockEC2API)(nil).StartNetworkInsightsAnalysisRequest), arg0)
+}
+
+// StartNetworkInsightsAnalysisWithContext mocks base method
+func (m *MockEC2API) StartNetworkInsightsAnalysisWithContext(arg0 context.Context, arg1 *ec2.StartNetworkInsightsAnalysisInput, arg2 ...request.Option) (*ec2.StartNetworkInsightsAnalysisOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "StartNetworkInsightsAnalysisWithContext", varargs...)
+	ret0, _ := ret[0].(*ec2.StartNetworkInsightsAnalysisOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// StartNetworkInsightsAnalysisWithContext indicates an expected call of StartNetworkInsightsAnalysisWithContext
+func (mr *MockEC2APIMockRecorder) StartNetworkInsightsAnalysisWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartNetworkInsightsAnalysisWithContext", reflect.TypeOf((*MockEC2API)(nil).StartNetworkInsightsAnalysisWithContext), varargs...)
 }
 
 // StartVpcEndpointServicePrivateDnsVerification mocks base method

--- a/pkg/cloud/services/eks/mock_eksiface/eksapi_mock.go
+++ b/pkg/cloud/services/eks/mock_eksiface/eksapi_mock.go
@@ -51,6 +51,56 @@ func (m *MockEKSAPI) EXPECT() *MockEKSAPIMockRecorder {
 	return m.recorder
 }
 
+// CreateAddon mocks base method
+func (m *MockEKSAPI) CreateAddon(arg0 *eks.CreateAddonInput) (*eks.CreateAddonOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAddon", arg0)
+	ret0, _ := ret[0].(*eks.CreateAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateAddon indicates an expected call of CreateAddon
+func (mr *MockEKSAPIMockRecorder) CreateAddon(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAddon", reflect.TypeOf((*MockEKSAPI)(nil).CreateAddon), arg0)
+}
+
+// CreateAddonRequest mocks base method
+func (m *MockEKSAPI) CreateAddonRequest(arg0 *eks.CreateAddonInput) (*request.Request, *eks.CreateAddonOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAddonRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*eks.CreateAddonOutput)
+	return ret0, ret1
+}
+
+// CreateAddonRequest indicates an expected call of CreateAddonRequest
+func (mr *MockEKSAPIMockRecorder) CreateAddonRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAddonRequest", reflect.TypeOf((*MockEKSAPI)(nil).CreateAddonRequest), arg0)
+}
+
+// CreateAddonWithContext mocks base method
+func (m *MockEKSAPI) CreateAddonWithContext(arg0 context.Context, arg1 *eks.CreateAddonInput, arg2 ...request.Option) (*eks.CreateAddonOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CreateAddonWithContext", varargs...)
+	ret0, _ := ret[0].(*eks.CreateAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateAddonWithContext indicates an expected call of CreateAddonWithContext
+func (mr *MockEKSAPIMockRecorder) CreateAddonWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAddonWithContext", reflect.TypeOf((*MockEKSAPI)(nil).CreateAddonWithContext), varargs...)
+}
+
 // CreateCluster mocks base method
 func (m *MockEKSAPI) CreateCluster(arg0 *eks.CreateClusterInput) (*eks.CreateClusterOutput, error) {
 	m.ctrl.T.Helper()
@@ -201,6 +251,56 @@ func (mr *MockEKSAPIMockRecorder) CreateNodegroupWithContext(arg0, arg1 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateNodegroupWithContext", reflect.TypeOf((*MockEKSAPI)(nil).CreateNodegroupWithContext), varargs...)
 }
 
+// DeleteAddon mocks base method
+func (m *MockEKSAPI) DeleteAddon(arg0 *eks.DeleteAddonInput) (*eks.DeleteAddonOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAddon", arg0)
+	ret0, _ := ret[0].(*eks.DeleteAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteAddon indicates an expected call of DeleteAddon
+func (mr *MockEKSAPIMockRecorder) DeleteAddon(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAddon", reflect.TypeOf((*MockEKSAPI)(nil).DeleteAddon), arg0)
+}
+
+// DeleteAddonRequest mocks base method
+func (m *MockEKSAPI) DeleteAddonRequest(arg0 *eks.DeleteAddonInput) (*request.Request, *eks.DeleteAddonOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAddonRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*eks.DeleteAddonOutput)
+	return ret0, ret1
+}
+
+// DeleteAddonRequest indicates an expected call of DeleteAddonRequest
+func (mr *MockEKSAPIMockRecorder) DeleteAddonRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAddonRequest", reflect.TypeOf((*MockEKSAPI)(nil).DeleteAddonRequest), arg0)
+}
+
+// DeleteAddonWithContext mocks base method
+func (m *MockEKSAPI) DeleteAddonWithContext(arg0 context.Context, arg1 *eks.DeleteAddonInput, arg2 ...request.Option) (*eks.DeleteAddonOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DeleteAddonWithContext", varargs...)
+	ret0, _ := ret[0].(*eks.DeleteAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteAddonWithContext indicates an expected call of DeleteAddonWithContext
+func (mr *MockEKSAPIMockRecorder) DeleteAddonWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAddonWithContext", reflect.TypeOf((*MockEKSAPI)(nil).DeleteAddonWithContext), varargs...)
+}
+
 // DeleteCluster mocks base method
 func (m *MockEKSAPI) DeleteCluster(arg0 *eks.DeleteClusterInput) (*eks.DeleteClusterOutput, error) {
 	m.ctrl.T.Helper()
@@ -349,6 +449,139 @@ func (mr *MockEKSAPIMockRecorder) DeleteNodegroupWithContext(arg0, arg1 interfac
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteNodegroupWithContext", reflect.TypeOf((*MockEKSAPI)(nil).DeleteNodegroupWithContext), varargs...)
+}
+
+// DescribeAddon mocks base method
+func (m *MockEKSAPI) DescribeAddon(arg0 *eks.DescribeAddonInput) (*eks.DescribeAddonOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAddon", arg0)
+	ret0, _ := ret[0].(*eks.DescribeAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAddon indicates an expected call of DescribeAddon
+func (mr *MockEKSAPIMockRecorder) DescribeAddon(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddon", reflect.TypeOf((*MockEKSAPI)(nil).DescribeAddon), arg0)
+}
+
+// DescribeAddonRequest mocks base method
+func (m *MockEKSAPI) DescribeAddonRequest(arg0 *eks.DescribeAddonInput) (*request.Request, *eks.DescribeAddonOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAddonRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*eks.DescribeAddonOutput)
+	return ret0, ret1
+}
+
+// DescribeAddonRequest indicates an expected call of DescribeAddonRequest
+func (mr *MockEKSAPIMockRecorder) DescribeAddonRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddonRequest", reflect.TypeOf((*MockEKSAPI)(nil).DescribeAddonRequest), arg0)
+}
+
+// DescribeAddonVersions mocks base method
+func (m *MockEKSAPI) DescribeAddonVersions(arg0 *eks.DescribeAddonVersionsInput) (*eks.DescribeAddonVersionsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAddonVersions", arg0)
+	ret0, _ := ret[0].(*eks.DescribeAddonVersionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAddonVersions indicates an expected call of DescribeAddonVersions
+func (mr *MockEKSAPIMockRecorder) DescribeAddonVersions(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddonVersions", reflect.TypeOf((*MockEKSAPI)(nil).DescribeAddonVersions), arg0)
+}
+
+// DescribeAddonVersionsPages mocks base method
+func (m *MockEKSAPI) DescribeAddonVersionsPages(arg0 *eks.DescribeAddonVersionsInput, arg1 func(*eks.DescribeAddonVersionsOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAddonVersionsPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeAddonVersionsPages indicates an expected call of DescribeAddonVersionsPages
+func (mr *MockEKSAPIMockRecorder) DescribeAddonVersionsPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddonVersionsPages", reflect.TypeOf((*MockEKSAPI)(nil).DescribeAddonVersionsPages), arg0, arg1)
+}
+
+// DescribeAddonVersionsPagesWithContext mocks base method
+func (m *MockEKSAPI) DescribeAddonVersionsPagesWithContext(arg0 context.Context, arg1 *eks.DescribeAddonVersionsInput, arg2 func(*eks.DescribeAddonVersionsOutput, bool) bool, arg3 ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeAddonVersionsPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DescribeAddonVersionsPagesWithContext indicates an expected call of DescribeAddonVersionsPagesWithContext
+func (mr *MockEKSAPIMockRecorder) DescribeAddonVersionsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddonVersionsPagesWithContext", reflect.TypeOf((*MockEKSAPI)(nil).DescribeAddonVersionsPagesWithContext), varargs...)
+}
+
+// DescribeAddonVersionsRequest mocks base method
+func (m *MockEKSAPI) DescribeAddonVersionsRequest(arg0 *eks.DescribeAddonVersionsInput) (*request.Request, *eks.DescribeAddonVersionsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DescribeAddonVersionsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*eks.DescribeAddonVersionsOutput)
+	return ret0, ret1
+}
+
+// DescribeAddonVersionsRequest indicates an expected call of DescribeAddonVersionsRequest
+func (mr *MockEKSAPIMockRecorder) DescribeAddonVersionsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddonVersionsRequest", reflect.TypeOf((*MockEKSAPI)(nil).DescribeAddonVersionsRequest), arg0)
+}
+
+// DescribeAddonVersionsWithContext mocks base method
+func (m *MockEKSAPI) DescribeAddonVersionsWithContext(arg0 context.Context, arg1 *eks.DescribeAddonVersionsInput, arg2 ...request.Option) (*eks.DescribeAddonVersionsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeAddonVersionsWithContext", varargs...)
+	ret0, _ := ret[0].(*eks.DescribeAddonVersionsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAddonVersionsWithContext indicates an expected call of DescribeAddonVersionsWithContext
+func (mr *MockEKSAPIMockRecorder) DescribeAddonVersionsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddonVersionsWithContext", reflect.TypeOf((*MockEKSAPI)(nil).DescribeAddonVersionsWithContext), varargs...)
+}
+
+// DescribeAddonWithContext mocks base method
+func (m *MockEKSAPI) DescribeAddonWithContext(arg0 context.Context, arg1 *eks.DescribeAddonInput, arg2 ...request.Option) (*eks.DescribeAddonOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "DescribeAddonWithContext", varargs...)
+	ret0, _ := ret[0].(*eks.DescribeAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DescribeAddonWithContext indicates an expected call of DescribeAddonWithContext
+func (mr *MockEKSAPIMockRecorder) DescribeAddonWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeAddonWithContext", reflect.TypeOf((*MockEKSAPI)(nil).DescribeAddonWithContext), varargs...)
 }
 
 // DescribeCluster mocks base method
@@ -549,6 +782,89 @@ func (mr *MockEKSAPIMockRecorder) DescribeUpdateWithContext(arg0, arg1 interface
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DescribeUpdateWithContext", reflect.TypeOf((*MockEKSAPI)(nil).DescribeUpdateWithContext), varargs...)
+}
+
+// ListAddons mocks base method
+func (m *MockEKSAPI) ListAddons(arg0 *eks.ListAddonsInput) (*eks.ListAddonsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAddons", arg0)
+	ret0, _ := ret[0].(*eks.ListAddonsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAddons indicates an expected call of ListAddons
+func (mr *MockEKSAPIMockRecorder) ListAddons(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAddons", reflect.TypeOf((*MockEKSAPI)(nil).ListAddons), arg0)
+}
+
+// ListAddonsPages mocks base method
+func (m *MockEKSAPI) ListAddonsPages(arg0 *eks.ListAddonsInput, arg1 func(*eks.ListAddonsOutput, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAddonsPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ListAddonsPages indicates an expected call of ListAddonsPages
+func (mr *MockEKSAPIMockRecorder) ListAddonsPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAddonsPages", reflect.TypeOf((*MockEKSAPI)(nil).ListAddonsPages), arg0, arg1)
+}
+
+// ListAddonsPagesWithContext mocks base method
+func (m *MockEKSAPI) ListAddonsPagesWithContext(arg0 context.Context, arg1 *eks.ListAddonsInput, arg2 func(*eks.ListAddonsOutput, bool) bool, arg3 ...request.Option) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListAddonsPagesWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ListAddonsPagesWithContext indicates an expected call of ListAddonsPagesWithContext
+func (mr *MockEKSAPIMockRecorder) ListAddonsPagesWithContext(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAddonsPagesWithContext", reflect.TypeOf((*MockEKSAPI)(nil).ListAddonsPagesWithContext), varargs...)
+}
+
+// ListAddonsRequest mocks base method
+func (m *MockEKSAPI) ListAddonsRequest(arg0 *eks.ListAddonsInput) (*request.Request, *eks.ListAddonsOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAddonsRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*eks.ListAddonsOutput)
+	return ret0, ret1
+}
+
+// ListAddonsRequest indicates an expected call of ListAddonsRequest
+func (mr *MockEKSAPIMockRecorder) ListAddonsRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAddonsRequest", reflect.TypeOf((*MockEKSAPI)(nil).ListAddonsRequest), arg0)
+}
+
+// ListAddonsWithContext mocks base method
+func (m *MockEKSAPI) ListAddonsWithContext(arg0 context.Context, arg1 *eks.ListAddonsInput, arg2 ...request.Option) (*eks.ListAddonsOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "ListAddonsWithContext", varargs...)
+	ret0, _ := ret[0].(*eks.ListAddonsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAddonsWithContext indicates an expected call of ListAddonsWithContext
+func (mr *MockEKSAPIMockRecorder) ListAddonsWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAddonsWithContext", reflect.TypeOf((*MockEKSAPI)(nil).ListAddonsWithContext), varargs...)
 }
 
 // ListClusters mocks base method
@@ -1033,6 +1349,56 @@ func (mr *MockEKSAPIMockRecorder) UntagResourceWithContext(arg0, arg1 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UntagResourceWithContext", reflect.TypeOf((*MockEKSAPI)(nil).UntagResourceWithContext), varargs...)
 }
 
+// UpdateAddon mocks base method
+func (m *MockEKSAPI) UpdateAddon(arg0 *eks.UpdateAddonInput) (*eks.UpdateAddonOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAddon", arg0)
+	ret0, _ := ret[0].(*eks.UpdateAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAddon indicates an expected call of UpdateAddon
+func (mr *MockEKSAPIMockRecorder) UpdateAddon(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAddon", reflect.TypeOf((*MockEKSAPI)(nil).UpdateAddon), arg0)
+}
+
+// UpdateAddonRequest mocks base method
+func (m *MockEKSAPI) UpdateAddonRequest(arg0 *eks.UpdateAddonInput) (*request.Request, *eks.UpdateAddonOutput) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAddonRequest", arg0)
+	ret0, _ := ret[0].(*request.Request)
+	ret1, _ := ret[1].(*eks.UpdateAddonOutput)
+	return ret0, ret1
+}
+
+// UpdateAddonRequest indicates an expected call of UpdateAddonRequest
+func (mr *MockEKSAPIMockRecorder) UpdateAddonRequest(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAddonRequest", reflect.TypeOf((*MockEKSAPI)(nil).UpdateAddonRequest), arg0)
+}
+
+// UpdateAddonWithContext mocks base method
+func (m *MockEKSAPI) UpdateAddonWithContext(arg0 context.Context, arg1 *eks.UpdateAddonInput, arg2 ...request.Option) (*eks.UpdateAddonOutput, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateAddonWithContext", varargs...)
+	ret0, _ := ret[0].(*eks.UpdateAddonOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAddonWithContext indicates an expected call of UpdateAddonWithContext
+func (mr *MockEKSAPIMockRecorder) UpdateAddonWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAddonWithContext", reflect.TypeOf((*MockEKSAPI)(nil).UpdateAddonWithContext), varargs...)
+}
+
 // UpdateClusterConfig mocks base method
 func (m *MockEKSAPI) UpdateClusterConfig(arg0 *eks.UpdateClusterConfigInput) (*eks.UpdateClusterConfigOutput, error) {
 	m.ctrl.T.Helper()
@@ -1231,6 +1597,72 @@ func (mr *MockEKSAPIMockRecorder) UpdateNodegroupVersionWithContext(arg0, arg1 i
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateNodegroupVersionWithContext", reflect.TypeOf((*MockEKSAPI)(nil).UpdateNodegroupVersionWithContext), varargs...)
+}
+
+// WaitUntilAddonActive mocks base method
+func (m *MockEKSAPI) WaitUntilAddonActive(arg0 *eks.DescribeAddonInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilAddonActive", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilAddonActive indicates an expected call of WaitUntilAddonActive
+func (mr *MockEKSAPIMockRecorder) WaitUntilAddonActive(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilAddonActive", reflect.TypeOf((*MockEKSAPI)(nil).WaitUntilAddonActive), arg0)
+}
+
+// WaitUntilAddonActiveWithContext mocks base method
+func (m *MockEKSAPI) WaitUntilAddonActiveWithContext(arg0 context.Context, arg1 *eks.DescribeAddonInput, arg2 ...request.WaiterOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WaitUntilAddonActiveWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilAddonActiveWithContext indicates an expected call of WaitUntilAddonActiveWithContext
+func (mr *MockEKSAPIMockRecorder) WaitUntilAddonActiveWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilAddonActiveWithContext", reflect.TypeOf((*MockEKSAPI)(nil).WaitUntilAddonActiveWithContext), varargs...)
+}
+
+// WaitUntilAddonDeleted mocks base method
+func (m *MockEKSAPI) WaitUntilAddonDeleted(arg0 *eks.DescribeAddonInput) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "WaitUntilAddonDeleted", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilAddonDeleted indicates an expected call of WaitUntilAddonDeleted
+func (mr *MockEKSAPIMockRecorder) WaitUntilAddonDeleted(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilAddonDeleted", reflect.TypeOf((*MockEKSAPI)(nil).WaitUntilAddonDeleted), arg0)
+}
+
+// WaitUntilAddonDeletedWithContext mocks base method
+func (m *MockEKSAPI) WaitUntilAddonDeletedWithContext(arg0 context.Context, arg1 *eks.DescribeAddonInput, arg2 ...request.WaiterOption) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WaitUntilAddonDeletedWithContext", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// WaitUntilAddonDeletedWithContext indicates an expected call of WaitUntilAddonDeletedWithContext
+func (mr *MockEKSAPIMockRecorder) WaitUntilAddonDeletedWithContext(arg0, arg1 interface{}, arg2 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WaitUntilAddonDeletedWithContext", reflect.TypeOf((*MockEKSAPI)(nil).WaitUntilAddonDeletedWithContext), varargs...)
 }
 
 // WaitUntilClusterActive mocks base method


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds the ability to enable the new ASG capacity rebalance feature.

This only makes sense when there are Spot instances in the ASG (i.e. when `.spec.mixedInstancesPolicy.instancesDistribution.onDemandPercentageAboveBaseCapacity < 100`) but AWS allows to enable capacity rebalance even when spot percentage is 0%. Worth adding some validation?

The new `.spec.capacityRebalance` defaults to `false` and is set as optional for backwards compatibility.

This is a backport of https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2288 to `v0.6.1`

