### PR TITLE
Don't set DesiredCapacity if ExternallyManagedReplicaCount=true

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -279,7 +279,7 @@ func (s *Service) UpdateASG(scope *scope.MachinePoolScope) error {
 		CapacityRebalance:    aws.Bool(scope.AWSMachinePool.Spec.CapacityRebalance),
 	}
 
-	if scope.MachinePool.Spec.Replicas != nil {
+	if scope.MachinePool.Spec.Replicas != nil && !scope.MachinePool.Spec.ExternallyManagedReplicaCount {
 		input.DesiredCapacity = aws.Int64(int64(*scope.MachinePool.Spec.Replicas))
 	}
 


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:
- Honor the `ExternallyManagedReplicaCount`.
- Allow `UpdateAutoScalingGroup` API calls to implicitly increase ASG `DesiredCapacity` when it is set below `minSize`.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. 
2. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE"....however we encourage contributors to never use this as release notes are incredible useful.
-->
```release-note
Honor the ExternallyManagedReplicaCount field and allow UpdateAutoScalingGroup API calls to implicitly increase ASG DesiredCapacity when it is set below minSize.
```
