### PR TITLE
🐛: lookup existing launchtemplates by name

### DIFF
--- a/pkg/cloud/services/ec2/launchtemplate.go
+++ b/pkg/cloud/services/ec2/launchtemplate.go
@@ -34,16 +34,12 @@ import (
 
 // GetLaunchTemplate returns the existing LaunchTemplate or nothing if it doesn't exist.
 // For now by name until we need the input to be something different
-func (s *Service) GetLaunchTemplate(id string) (*expinfrav1.AWSLaunchTemplate, error) {
-	if id == "" {
-		return nil, nil
-	}
-
+func (s *Service) GetLaunchTemplate(name string) (*expinfrav1.AWSLaunchTemplate, error) {
 	s.scope.V(2).Info("Looking for existing LaunchTemplates")
 
 	input := &ec2.DescribeLaunchTemplateVersionsInput{
-		LaunchTemplateId: aws.String(id),
-		Versions:         aws.StringSlice([]string{expinfrav1.LaunchTemplateLatestVersion}),
+		LaunchTemplateName: aws.String(name),
+		Versions:           aws.StringSlice([]string{expinfrav1.LaunchTemplateLatestVersion}),
 	}
 
 	out, err := s.EC2Client.DescribeLaunchTemplateVersions(input)
@@ -115,7 +111,7 @@ func (s *Service) CreateLaunchTemplateVersion(scope *scope.MachinePoolScope, ima
 
 	input := &ec2.CreateLaunchTemplateVersionInput{
 		LaunchTemplateData: launchTemplateData,
-		LaunchTemplateId:   aws.String(scope.AWSMachinePool.Status.LaunchTemplateID),
+		LaunchTemplateName: aws.String(scope.AWSMachinePool.Name),
 	}
 
 	_, err = s.EC2Client.CreateLaunchTemplateVersion(input)

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -46,8 +46,8 @@ func TestGetLaunchTemplate(t *testing.T) {
 			launchTemplateName: "foo",
 			expect: func(m *mock_ec2iface.MockEC2APIMockRecorder) {
 				m.DescribeLaunchTemplateVersions(gomock.Eq(&ec2.DescribeLaunchTemplateVersionsInput{
-					LaunchTemplateId: aws.String("foo"),
-					Versions:         []*string{aws.String("$Latest")},
+					LaunchTemplateName: aws.String("foo"),
+					Versions:           []*string{aws.String("$Latest")},
 				})).
 					Return(nil, awserrors.NewNotFound("not found"))
 			},


### PR DESCRIPTION
**What this PR does / why we need it**:
Sometimes when we recreate machinepools the old launchtemplate is still around. CAPA can't create a new launchtemplate because of a name collision. We should adopt the old launchtemplate instead of creating a new one. 
https://newrelic.atlassian.net/browse/CONFAB-4926 
