### PR TITLE
🐛 return after creating LaunchTemplate, fix RBAC

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -91,6 +91,7 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - infrastructure.cluster.x-k8s.io

--- a/exp/controllers/awsmachinepool_controller.go
+++ b/exp/controllers/awsmachinepool_controller.go
@@ -78,7 +78,7 @@ func (r *AWSMachinePoolReconciler) getEC2Service(scope scope.EC2Scope) services.
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachinepools,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=infrastructure.cluster.x-k8s.io,resources=awsmachinepools/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=exp.cluster.x-k8s.io,resources=machinepools,verbs=get;list;watch;patch
-// +kubebuilder:rbac:groups=exp.cluster.x-k8s.io,resources=machinepools/status,verbs=get;list;watch
+// +kubebuilder:rbac:groups=exp.cluster.x-k8s.io,resources=machinepools/status,verbs=get;list;watch;patch
 // +kubebuilder:rbac:groups="",resources=events,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups="",resources=secrets;,verbs=get;list;watch
 
@@ -416,10 +416,13 @@ func (r *AWSMachinePoolReconciler) reconcileLaunchTemplate(machinePoolScope *sco
 			return err
 		}
 		machinePoolScope.AWSMachinePool.Status.LaunchTemplateID = launchTemplateID
-	} else {
-		machinePoolScope.AWSMachinePool.Status.LaunchTemplateID = launchTemplate.ID
+		if err := machinePoolScope.PatchObject(); err != nil {
+			return err
+		}
+		return nil
 	}
 
+	machinePoolScope.AWSMachinePool.Status.LaunchTemplateID = launchTemplate.ID
 	if err := machinePoolScope.PatchObject(); err != nil {
 		return err
 	}


### PR DESCRIPTION
If a LaunchTemplate doesn't exist the first call to `ec2svc.GetLaunchTemplate()` will return `nil`. In that case we need to create the LT and end the reconciliation loop, otherwise it will crash later on `ec2svc.LaunchTemplateNeedsUpdate()`.

This is fine-ish when creating a single LT since the `ec2svc.CreateLaunchTemplate()` upstream command has been launched and in the next run we'll get a LT ID. But when creating multiple LTs at once this crash causes the entire reconciliation loop to fail and the controller to enter a backoff process that slows things down a lot.

Also fix missing RBAC perms that caused a `User \"system:serviceaccount:capa-system:default\" cannot patch resource \"machinepools/status\"` error.