### PR TITLE
fix: handle LaunchTemplateNameNotFound error

### DIFF
--- a/bootstrap/eks/controllers/suite_test.go
+++ b/bootstrap/eks/controllers/suite_test.go
@@ -30,8 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/printer"
 
-	expinfrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
-	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
+	"sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
 	controlplanev1alpha3 "sigs.k8s.io/cluster-api-provider-aws/controlplane/eks/api/v1alpha3"
 	// +kubebuilder:scaffold:imports
 )
@@ -70,9 +69,8 @@ var _ = BeforeSuite(func(done Done) {
 	Expect(cfg).ToNot(BeNil())
 
 	Expect(clusterv1.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(infrav1.AddToScheme(scheme.Scheme)).To(Succeed())
+	Expect(v1alpha3.AddToScheme(scheme.Scheme)).To(Succeed())
 	Expect(controlplanev1alpha3.AddToScheme(scheme.Scheme)).To(Succeed())
-	Expect(expinfrav1.AddToScheme(scheme.Scheme)).To(Succeed())
 
 	// +kubebuilder:scaffold:scheme
 

--- a/pkg/cloud/awserrors/errors.go
+++ b/pkg/cloud/awserrors/errors.go
@@ -24,24 +24,25 @@ import (
 )
 
 const (
-	AuthFailure             = "AuthFailure"
-	InUseIPAddress          = "InvalidIPAddress.InUse"
-	GroupNotFound           = "InvalidGroup.NotFound"
-	PermissionNotFound      = "InvalidPermission.NotFound"
-	VPCNotFound             = "InvalidVpcID.NotFound"
-	SubnetNotFound          = "InvalidSubnetID.NotFound"
-	InternetGatewayNotFound = "InvalidInternetGatewayID.NotFound"
-	NATGatewayNotFound      = "InvalidNatGatewayID.NotFound"
-	GatewayNotFound         = "InvalidGatewayID.NotFound"
-	EIPNotFound             = "InvalidElasticIpID.NotFound"
-	RouteTableNotFound      = "InvalidRouteTableID.NotFound"
-	LoadBalancerNotFound    = "LoadBalancerNotFound"
-	ResourceNotFound        = "InvalidResourceID.NotFound"
-	InvalidSubnet           = "InvalidSubnet"
-	AssociationIDNotFound   = "InvalidAssociationID.NotFound"
-	InvalidInstanceID       = "InvalidInstanceID.NotFound"
-	ResourceExists          = "ResourceExistsException"
-	NoCredentialProviders   = "NoCredentialProviders"
+	AuthFailure                = "AuthFailure"
+	InUseIPAddress             = "InvalidIPAddress.InUse"
+	GroupNotFound              = "InvalidGroup.NotFound"
+	PermissionNotFound         = "InvalidPermission.NotFound"
+	VPCNotFound                = "InvalidVpcID.NotFound"
+	SubnetNotFound             = "InvalidSubnetID.NotFound"
+	InternetGatewayNotFound    = "InvalidInternetGatewayID.NotFound"
+	NATGatewayNotFound         = "InvalidNatGatewayID.NotFound"
+	GatewayNotFound            = "InvalidGatewayID.NotFound"
+	EIPNotFound                = "InvalidElasticIpID.NotFound"
+	RouteTableNotFound         = "InvalidRouteTableID.NotFound"
+	LoadBalancerNotFound       = "LoadBalancerNotFound"
+	ResourceNotFound           = "InvalidResourceID.NotFound"
+	InvalidSubnet              = "InvalidSubnet"
+	AssociationIDNotFound      = "InvalidAssociationID.NotFound"
+	InvalidInstanceID          = "InvalidInstanceID.NotFound"
+	LaunchTemplateNameNotFound = "InvalidLaunchTemplateName.NotFoundException"
+	ResourceExists             = "ResourceExistsException"
+	NoCredentialProviders      = "NoCredentialProviders"
 )
 
 var _ error = &EC2Error{}
@@ -138,6 +139,8 @@ func IsInvalidNotFoundError(err error) bool {
 		case InvalidInstanceID:
 			return true
 		case ssm.ErrCodeParameterNotFound:
+			return true
+		case LaunchTemplateNameNotFound:
 			return true
 		}
 	}

--- a/pkg/cloud/services/ec2/launchtemplate_test.go
+++ b/pkg/cloud/services/ec2/launchtemplate_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/golang/mock/gomock"
 	infrav1 "sigs.k8s.io/cluster-api-provider-aws/api/v1alpha3"
@@ -87,7 +88,11 @@ func TestGetLaunchTemplate(t *testing.T) {
 					LaunchTemplateName: aws.String("foo"),
 					Versions:           []*string{aws.String("$Latest")},
 				})).
-					Return(nil, awserrors.NewNotFound("not found"))
+					Return(nil, awserr.New(
+						awserrors.LaunchTemplateNameNotFound,
+						"The specified launch template, with template name foo, does not exist.",
+						nil,
+					))
 			},
 			check: func(launchtemplate *expinfrav1.AWSLaunchTemplate, userdatahash string, err error) {
 				if err != nil {

--- a/scripts/fetch_ext_bins.sh
+++ b/scripts/fetch_ext_bins.sh
@@ -26,7 +26,7 @@ if [[ -n "${TRACE}" ]]; then
   set -x
 fi
 
-k8s_version=1.16.4
+k8s_version=1.19.2
 goarch=amd64
 goos="unknown"
 
@@ -95,7 +95,9 @@ function fetch_tools {
 
   kb_tools_archive_path="${tmp_root}/${kb_tools_archive_name}"
   if [[ ! -f ${kb_tools_archive_path} ]]; then
+    echo ${kb_tools_download_url}
     curl -fsL ${kb_tools_download_url} -o "${kb_tools_archive_path}"
+
   fi
   tar -zvxf "${kb_tools_archive_path}" -C "${tmp_root}/"
 }


### PR DESCRIPTION
<!-- please add a icon to the title of this PR (see https://sigs.k8s.io/cluster-api/VERSIONING.md), and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, minor or feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

Backports https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/2411 so non-existing LaunchTemplate errors are correctly handled.

Also updating the test binaries version and the tests which were not passing.

