### PR TITLE
Revert "fix: adds deleteBastionSecurityGroup to DeleteBastion() [ off release branch ]"

### DIFF
--- a/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
+++ b/controlplane/eks/controllers/awsmanagedcontrolplane_controller.go
@@ -195,6 +195,7 @@ func (r *AWSManagedControlPlaneReconciler) reconcileNormal(ctx context.Context, 
 	}
 
 	sgRoles := []infrav1.SecurityGroupRole{
+		infrav1.SecurityGroupBastion,
 		infrav1.SecurityGroupEKSNodeAdditional,
 	}
 

--- a/pkg/cloud/services/ec2/bastion.go
+++ b/pkg/cloud/services/ec2/bastion.go
@@ -98,7 +98,7 @@ func (s *Service) ReconcileBastion() error {
 	return nil
 }
 
-// DeleteBastion deletes the Bastion instance and related security groups
+// DeleteBastion deletes the Bastion instance
 func (s *Service) DeleteBastion() error {
 	instance, err := s.describeBastionInstance()
 	if err != nil {

--- a/pkg/cloud/services/securitygroup/securitygroups.go
+++ b/pkg/cloud/services/securitygroup/securitygroups.go
@@ -79,10 +79,7 @@ func (s *Service) ReconcileSecurityGroups() error {
 		existing, ok := sgs[*sg.GroupName]
 
 		if !ok {
-			// if it is disabled and the role is bastion, skip
-			if !s.scope.Bastion().Enabled && role == "bastion" {
-				break
-			} else if err := s.createSecurityGroup(role, sg); err != nil {
+			if err := s.createSecurityGroup(role, sg); err != nil {
 				return err
 			}
 
@@ -465,11 +462,9 @@ func (s *Service) getSecurityGroupIngressRules(role infrav1.SecurityGroupRole) (
 		}
 		return append(cniRules, rules...), nil
 	case infrav1.SecurityGroupEKSNodeAdditional:
-		if !s.scope.Bastion().Enabled {
-			return infrav1.IngressRules{
-				s.defaultSSHIngressRule(s.scope.SecurityGroups()[infrav1.SecurityGroupBastion].ID),
-			}, nil
-		}
+		return infrav1.IngressRules{
+			s.defaultSSHIngressRule(s.scope.SecurityGroups()[infrav1.SecurityGroupBastion].ID),
+		}, nil
 	case infrav1.SecurityGroupAPIServerLB:
 		return infrav1.IngressRules{
 			{


### PR DESCRIPTION
Reverts newrelic-forks/cluster-api-provider-aws#84

found the problem with the controlplane controller instead. https://github.com/kubernetes-sigs/cluster-api-provider-aws/pull/3028

one day we'll get off this fork and won't have to cherry pick. one day.