### PR TITLE
Changes 1.5.2

### DIFF
--- a/pkg/cloud/services/autoscaling/autoscalinggroup.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup.go
@@ -83,8 +83,9 @@ func (s *Service) SDKToAutoScalingGroup(v *autoscaling.Group) (*expinfrav1.AutoS
 	if len(v.Instances) > 0 {
 		for _, autoscalingInstance := range v.Instances {
 			tmp := &infrav1.Instance{
-				ID:    aws.StringValue(autoscalingInstance.InstanceId),
-				State: infrav1.InstanceState(*autoscalingInstance.LifecycleState),
+				ID:               aws.StringValue(autoscalingInstance.InstanceId),
+				State:            infrav1.InstanceState(*autoscalingInstance.LifecycleState),
+				AvailabilityZone: *autoscalingInstance.AvailabilityZone,
 			}
 			i.Instances = append(i.Instances, *tmp)
 		}

--- a/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
+++ b/pkg/cloud/services/autoscaling/autoscalinggroup_test.go
@@ -218,8 +218,9 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				},
 				Instances: []*autoscaling.Instance{
 					{
-						InstanceId:     aws.String("instanceId"),
-						LifecycleState: aws.String("lifecycleState"),
+						InstanceId:       aws.String("instanceId"),
+						LifecycleState:   aws.String("lifecycleState"),
+						AvailabilityZone: aws.String("us-east-1a"),
 					},
 				},
 			},
@@ -249,8 +250,9 @@ func TestService_SDKToAutoScalingGroup(t *testing.T) {
 				},
 				Instances: []infrav1.Instance{
 					{
-						ID:    "instanceId",
-						State: "lifecycleState",
+						ID:               "instanceId",
+						State:            "lifecycleState",
+						AvailabilityZone: "us-east-1a",
 					},
 				},
 			},

--- a/pkg/cloud/services/eks/nodegroup.go
+++ b/pkg/cloud/services/eks/nodegroup.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/cloud/services/wait"
 	"sigs.k8s.io/cluster-api-provider-aws/pkg/record"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
-	"sigs.k8s.io/cluster-api/controllers/noderefutil"
 )
 
 func (s *NodegroupService) describeNodegroup() (*eks.Nodegroup, error) {
@@ -573,12 +572,7 @@ func (s *NodegroupService) setStatus(ng *eks.Nodegroup) error {
 		for _, group := range groups.AutoScalingGroups {
 			replicas += int32(len(group.Instances))
 			for _, instance := range group.Instances {
-				id, err := noderefutil.NewProviderID(fmt.Sprintf("aws://%s/%s", *instance.AvailabilityZone, *instance.InstanceId))
-				if err != nil {
-					s.Error(err, "couldn't create provider ID for instance", "id", *instance.InstanceId)
-					continue
-				}
-				providerIDList = append(providerIDList, id.String())
+				providerIDList = append(providerIDList, fmt.Sprintf("aws:///%s/%s", *instance.AvailabilityZone, *instance.InstanceId))
 			}
 		}
 		managedPool.Spec.ProviderIDList = providerIDList


### PR DESCRIPTION
This change backports 2 commits that were introduced in 1.5.2 release:
1. [Add Instance AZ SDK API to CAPA API conversion](https://github.com/kubernetes-sigs/cluster-api-provider-aws/commit/4355402b31bb8126cef3a65275ceba8ee97be3c0)
2. [fix for providerIDList in managed node pools](https://github.com/kubernetes-sigs/cluster-api-provider-aws/commit/1fd417bdb05ce70a5028db8a85ab1d56e7680f3d)