### PR TITLE
feat: enable minSize 0 for v1alpha3 and v1alpha4 for awsmachinepools.infrastructure.cluster.x-k8s.io

### DIFF
--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_awsmachinepools.yaml
@@ -255,7 +255,7 @@ spec:
                 default: 1
                 description: MinSize defines the minimum size of the group.
                 format: int32
-                minimum: 1
+                minimum: 0
                 type: integer
               mixedInstancesPolicy:
                 description: MixedInstancesPolicy describes how multiple instance
@@ -716,7 +716,7 @@ spec:
                 default: 1
                 description: MinSize defines the minimum size of the group.
                 format: int32
-                minimum: 1
+                minimum: 0
                 type: integer
               mixedInstancesPolicy:
                 description: MixedInstancesPolicy describes how multiple instance

--- a/exp/api/v1alpha3/awsmachinepool_types.go
+++ b/exp/api/v1alpha3/awsmachinepool_types.go
@@ -42,7 +42,7 @@ type AWSMachinePoolSpec struct {
 
 	// MinSize defines the minimum size of the group.
 	// +kubebuilder:default=1
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	MinSize int32 `json:"minSize"`
 
 	// MaxSize defines the maximum size of the group.

--- a/exp/api/v1alpha4/awsmachinepool_types.go
+++ b/exp/api/v1alpha4/awsmachinepool_types.go
@@ -42,7 +42,7 @@ type AWSMachinePoolSpec struct {
 
 	// MinSize defines the minimum size of the group.
 	// +kubebuilder:default=1
-	// +kubebuilder:validation:Minimum=1
+	// +kubebuilder:validation:Minimum=0
 	MinSize int32 `json:"minSize"`
 
 	// MaxSize defines the maximum size of the group.


### PR DESCRIPTION
make generate-go-apis

<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

Adds support for scaling awsmachinepools.infrastructure.cluster.x-k8s.io/v1alpha3 and v1alpha4 to 0 instead of 1, already present for v1beta1 https://github.com/newrelic-forks/cluster-api-provider-aws/blob/v1.5.1-nr4/exp/api/v1beta1/awsmachinepool_types.go#L42,

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted -->

- [ ] squashed commits
- [ ] includes documentation
- [ ] adds unit tests
- [ ] adds or updates e2e tests
