### PR TITLE
Release v2.0.3 nr2

### DIFF
--- a/pkg/cloud/services/network/natgateways.go
+++ b/pkg/cloud/services/network/natgateways.go
@@ -184,6 +184,9 @@ func (s *Service) describeNatGatewaysBySubnet() (map[string]*ec2.NatGateway, err
 	err := s.EC2Client.DescribeNatGatewaysPages(describeNatGatewayInput,
 		func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool {
 			for _, r := range page.NatGateways {
+				if r.SubnetId == nil {
+					continue
+				}
 				gateways[*r.SubnetId] = r
 			}
 			return !lastPage

--- a/pkg/cloud/services/network/natgateways_test.go
+++ b/pkg/cloud/services/network/natgateways_test.go
@@ -339,6 +339,70 @@ func TestReconcileNatGateways(t *testing.T) {
 			},
 		},
 		{
+			name: "regional NAT gateway with nil SubnetId exists alongside valid gateway, should not panic",
+			input: []infrav1.SubnetSpec{
+				{
+					ID:               "subnet-1",
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.10.0/24",
+					IsPublic:         true,
+				},
+				{
+					ID:               "subnet-2",
+					AvailabilityZone: "us-east-1a",
+					CidrBlock:        "10.0.12.0/24",
+					IsPublic:         false,
+				},
+			},
+			expect: func(m *mocks.MockEC2APIMockRecorder) {
+				m.DescribeNatGatewaysPages(
+					gomock.Eq(&ec2.DescribeNatGatewaysInput{
+						Filter: []*ec2.Filter{
+							{
+								Name:   aws.String("vpc-id"),
+								Values: []*string{aws.String(subnetsVPCID)},
+							},
+							{
+								Name:   aws.String("state"),
+								Values: []*string{aws.String("pending"), aws.String("available")},
+							},
+						},
+					}),
+					gomock.Any()).Do(func(_, y interface{}) {
+					funct := y.(func(page *ec2.DescribeNatGatewaysOutput, lastPage bool) bool)
+					funct(&ec2.DescribeNatGatewaysOutput{NatGateways: []*ec2.NatGateway{
+						{
+							// Regional NAT gateway — no SubnetId, should be skipped
+							NatGatewayId: aws.String("regional-gateway"),
+							SubnetId:     nil,
+						},
+						{
+							NatGatewayId: aws.String("gateway"),
+							SubnetId:     aws.String("subnet-1"),
+							Tags: []*ec2.Tag{
+								{
+									Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/role"),
+									Value: aws.String("common"),
+								},
+								{
+									Key:   aws.String("Name"),
+									Value: aws.String("test-cluster-nat"),
+								},
+								{
+									Key:   aws.String("sigs.k8s.io/cluster-api-provider-aws/cluster/test-cluster"),
+									Value: aws.String("owned"),
+								},
+							},
+						},
+					}}, true)
+				}).Return(nil)
+
+				m.DescribeAddresses(gomock.Any()).Times(0)
+				m.AllocateAddress(gomock.Any()).Times(0)
+				m.CreateNatGateway(gomock.Any()).Times(0)
+			},
+		},
+		{
 			name: "public & private subnet declared, but don't exist yet",
 			input: []infrav1.SubnetSpec{
 				{


### PR DESCRIPTION
## Problem

  The `awsmanagedcontrolplane` reconciler  has been panicking continuously since May 7, blocking all kubeconfig token rotation. Because CAPA uses a pre-signed STS token (15 min TTL) in the CAPI kubeconfig secret, once
  rotation stopped the token expired and the CAPI remote connection probe began failing. With CAPI unable to reach the workload cluster, all machine drain and scale operations became stuck.

  ## Root Cause

  Regional NAT gateways are not associated with a subnet and return `SubnetId: nil` from the AWS EC2 API. The `describeNatGatewaysBySubnet` callback unconditionally dereferences `*r.SubnetId`, panicking whenever a Regional NAT gateway exists in
  the same VPC as the cluster's Zonal NAT gateways.

  natgateways.go:187: gateways[*r.SubnetId] = r  // nil deref on Regional NAT gateway

  The crash happens before kubeconfig rotation is reached, so every reconcile attempt fails silently and the token is never refreshed.

  ## Fix

  Add a nil guard to skip NAT gateways with no `SubnetId`:

  ```go
  if r.SubnetId == nil {
      continue
  }

  Testing

  - All existing TestReconcileNatGateways cases pass
  - New test case added: Regional NAT gateway with nil SubnetId alongside a valid Zonal gateway — verifies no panic and valid gateway is still processed correctly

  After merging

  1. Build and deploy v2.0.3-nr2 image to the management cluster
  2. Manually patch the expired kubeconfig token in stg-bouncy-robot-kubeconfig to restore CAPI connectivity immediately
  3. Verify RemoteConnectionProbe recovers and stuck machines resume draining
